### PR TITLE
Move example dependencies to own Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,8 @@ authors = ["The GAIO.jl Team"]
 version = "0.1.0"
 
 [deps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GLFW = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98"
-Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
-QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+GAIO = "33d280d1-ac47-4b0f-9c2e-fa6a385d0226"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/examples/examples.jl
+++ b/examples/examples.jl
@@ -1,0 +1,11 @@
+using GAIO
+using LinearAlgebra
+using StaticArrays
+using QuadGK
+using Interpolations
+using ForwardDiff
+
+include("henon.jl")
+include("lorenz.jl")
+include("knotted_flow.jl")
+include("cover_roots.jl")

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -1,6 +1,10 @@
 module GAIO
 
+using LinearAlgebra
 using StaticArrays
+using GLFW
+using ModernGL
+using LightGraphs
 
 export Box, BoxSet
 export boxset_empty, subdivide, subdivide!
@@ -25,24 +29,9 @@ include("boxset.jl")
 include("boxmap.jl")
 include("algorithms.jl")
 
-# simple visualization. TODO: move away from here
-using GLFW
-using ModernGL
-using LinearAlgebra
-
+# visualization
 include("plot/shader.jl")
 include("plot/camera.jl")
 include("plot/plot.jl")
-
-# examples. TODO: move away from here
-using QuadGK
-using Interpolations
-using LightGraphs
-using ForwardDiff
-
-include("../examples/henon.jl")
-include("../examples/lorenz.jl")
-include("../examples/knotted_flow.jl")
-include("../examples/cover_roots.jl")
 
 end # module


### PR DESCRIPTION
Fixes part of #11. Examples can now be tested as follows:

```julia
# open julia at GAIO.jl/examples
shell> cd GAIO.jl/examples/
/home/cafaxo/GAIO.jl/examples

(@v1.4) pkg> activate .
 Activating environment at `~/GAIO.jl/examples/Project.toml`

(examples) pkg> dev ../
# ...
(examples) pkg> instantiate
# ...
julia> include("examples.jl")
```
The dev and instantiate is only required for the first run.