### PR TITLE
Add transfer operator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["The GAIO.jl Team"]
 version = "0.1.0"
 
 [deps]
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 GLFW = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -1,16 +1,25 @@
 module GAIO
 
 using LinearAlgebra
+using SparseArrays
 using StaticArrays
 using GLFW
 using ModernGL
 using LightGraphs
+using Arpack
 
-export Box, BoxSet
-export boxset_empty, subdivide, subdivide!
+export Box
 
 export BoxPartition, RegularPartition, TreePartition
 export dimension, depth
+
+export BoxSet
+export boxset_empty, subdivide, subdivide!
+
+export BoxFun
+
+export TransferOperator
+export strongly_connected_components, matrix, eigs
 
 export BoxMap, PointDiscretizedMap
 export boxmap
@@ -26,6 +35,8 @@ abstract type BoxPartition{B <: Box} end
 include("partition_regular.jl")
 include("partition_tree.jl")
 include("boxset.jl")
+include("boxfun.jl")
+include("transfer_operator.jl")
 include("boxmap.jl")
 include("algorithms.jl")
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -20,35 +20,11 @@ function unstable_set!(g::BoxMap, boxset::BoxSet)
     return boxset
 end
 
-function strongly_connected_vertices(edges)
-    connected_vertices = Int[]
-    graph = SimpleDiGraph(Edge.(edges))
-    scc = strongly_connected_components(graph)
-
-    for k in 1:length(scc)
-        n = length(scc[k])
-        if n > 1
-            for i in 1:n
-                push!(connected_vertices, scc[k][i])
-            end
-        end
-    end
-
-    for k in vertices(graph)
-        if (k,k) in edges
-            push!(connected_vertices, k)
-        end
-    end
-
-    return connected_vertices
-end
-
 function chain_recurrent_set(g::BoxMap, boxset::BoxSet, depth::Int)
     for k in 1:depth
         boxset = subdivide(boxset)
-        edges, vertex_to_key = map_boxes_to_edges(g, boxset)
-        connected_vertices = strongly_connected_vertices(edges)
-        boxset = BoxSet(boxset.partition, Set(vertex_to_key[connected_vertices]))
+        G = transition_graph(g, boxset)
+        boxset = strongly_connected_components(G)
     end
 
     return boxset

--- a/src/box.jl
+++ b/src/box.jl
@@ -21,6 +21,8 @@ end
 
 Base.in(point, box::Box) = all(point .>= box.center - box.radius) && all(point .< box.center + box.radius)
 
+volume(box::Box) = prod(2 * box.radius)
+
 function Base.show(io::IO, box::Box) 
     print(io, "Box: center = $(box.center), radius = $(box.radius)")
 end

--- a/src/boxfun.jl
+++ b/src/boxfun.jl
@@ -1,0 +1,37 @@
+# TODO: cleanup type params. key type of partition must equal K
+struct BoxFun{P<:BoxPartition,K,V}
+    partition::P
+    dict::Dict{K,V}
+end
+
+function Base.sum(f, boxfun::BoxFun{K,V}) where {K,V}
+    return sum(let partition = boxfun.partition
+        pair -> begin
+            key, value = pair
+            box = key_to_box(partition, key)
+            return volume(box) * f(value)
+        end
+    end, boxfun.dict)
+end
+
+LinearAlgebra.norm(boxfun::BoxFun) = sqrt(sum(abs2, boxfun))
+
+function LinearAlgebra.normalize!(boxfun::BoxFun)
+    λ = inv(norm(boxfun))
+    map!(x -> λ*x, values(boxfun.dict))
+    return boxfun
+end
+
+import Base: ∘
+
+function ∘(f, boxfun::BoxFun{P,K,V}) where {P,K,V}
+    fV = typeof(f(first(values(boxfun.dict))))
+    dict = Dict{K,fV}()
+    sizehint!(dict, length(boxfun.dict))
+
+    for (key, value) in boxfun.dict
+        dict[key] = f(value)
+    end
+
+    return BoxFun(boxfun.partition, dict)
+end

--- a/src/boxmap.jl
+++ b/src/boxmap.jl
@@ -136,36 +136,45 @@ function (g::PointDiscretizedMap)(source::BoxSet; target = nothing)
     end
 end
 
-function map_boxes_to_edges(g::BoxMap, source::BoxSet)
-    K = keytype(typeof(source.partition))
-    edges = Set{Tuple{K,K}}()
+function invert_vector(x::AbstractVector{T}) where T
+    dict = Dict{T,Int}()
+    sizehint!(dict, length(x))
 
-    for (src, hit) in ParallelBoxIterator(g, source)
+    for i in 1:length(x)
+        dict[x[i]] = i
+    end
+
+    return dict
+end
+
+# TODO: this code is generally incorrect. only valid for RegularPartition and special choices of points
+function TransferOperator(g::PointDiscretizedMap, boxset::BoxSet)
+    boxlist = BoxList(boxset)
+    K = keytype(typeof(boxset.partition))
+    edges = Dict{Tuple{K,K},Int}()
+    #n = 0
+
+    for (src, hit) in ParallelBoxIterator(g, boxset)
         if hit !== nothing # check that point was inside domain
-            if hit in source.set
-                push!(edges, (src, hit))
+            if hit in boxset.set
+                # TODO: this calculates the hash of (src, hit) twice
+                # improve this once https://github.com/JuliaLang/julia/issues/31199 is resolved
+                edges[(src, hit)] = get(edges, (src, hit), 0) + 1
+                #n += 1
             end
         end
     end
 
-    vertex_to_key = K[]
-    key_to_vertex = Dict{K,Int}()
-    keyset = keys(key_to_vertex)
-    edges_translated = Tuple{Int,Int}[]
-    
-    for (src, hit) in edges
-        if !(src in keyset)
-            push!(vertex_to_key, src)
-            key_to_vertex[src] = length(vertex_to_key)
-        end
+    key_to_int = invert_vector(boxlist.keylist)
 
-        if !(hit in keyset)
-            push!(vertex_to_key, hit)
-            key_to_vertex[hit] = length(vertex_to_key)
-        end
+    edges_normed = Dict{Tuple{Int,Int},Float64}()
+    sizehint!(edges_normed, length(edges))
 
-        push!(edges_translated, (key_to_vertex[src], key_to_vertex[hit]))
+    n = length(g.points)
+
+    for (edge, weight) in edges
+        edges_normed[(key_to_int[edge[1]], key_to_int[edge[2]])] = weight / n
     end
 
-    return edges_translated, vertex_to_key
+    return TransferOperator(boxlist, edges_normed)
 end

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -448,3 +448,14 @@ end
 function plot(boxset::BoxSet{<:BoxPartition{<:Box{N}}}) where N
     return plot([GLBox{N}(box.center.data, box.radius.data, (1.0f0, 1.0f0, 1.0f0, 1.0f0)) for box in boxset])
 end
+
+function plot(boxfun::BoxFun)
+    barlist = GLBar1D[]
+
+    for (key, value) in boxfun.dict
+        box = key_to_box(boxfun.partition, key)
+        push!(barlist, GLBar1D(box.center[1], box.radius[1], value))
+    end
+
+    plot(barlist)
+end

--- a/src/transfer_operator.jl
+++ b/src/transfer_operator.jl
@@ -1,0 +1,80 @@
+struct BoxList{P<:BoxPartition,L<:AbstractVector}
+    partition::P
+    keylist::L
+end
+
+Base.length(list::BoxList) = length(list.keylist)
+Base.getindex(list::BoxList, x::AbstractVector) = BoxList(list.partition, list.keylist[x])
+
+BoxList(set::BoxSet) = BoxList(set.partition, collect(set.set))
+
+BoxSet(list::BoxList) = BoxSet(list.partition, Set(list.keylist))
+
+struct TransferOperator{L<:BoxList,W}
+    vertices::L
+    edges::Dict{Tuple{Int,Int},W}
+end
+
+function strongly_connected_components(gstar::TransferOperator)
+    graph = SimpleDiGraph(
+        [Edge(edge[1], edge[2]) for edge in keys(gstar.edges)]
+    )
+
+    sccs = LightGraphs.strongly_connected_components(graph)
+
+    connected_vertices = Int[]
+
+    for scc in sccs
+        if length(scc) > 1 || has_edge(graph, scc[1], scc[1])
+            append!(connected_vertices, scc)
+        end
+    end
+
+    return BoxSet(gstar.vertices[connected_vertices])
+end
+
+function matrix(gstar::TransferOperator{L,W}) where {L,W}
+    num_edges = length(gstar.edges)
+
+    I = Vector{Int}()
+    sizehint!(I, num_edges)
+
+    J = Vector{Int}()
+    sizehint!(J, num_edges)
+
+    V = Vector{W}()
+    sizehint!(V, num_edges)
+
+    for (edge, weight) in gstar.edges
+        push!(I, edge[1])
+        push!(J, edge[2])
+        push!(V, weight)
+    end
+
+    n = length(gstar.vertices)
+    return sparse(I, J, V, n, n)
+end
+
+function Arpack.eigs(gstar::TransferOperator{BoxList{P,L}}; nev::Int=1) where {P,L}
+    G = matrix(gstar)
+
+    λ, ϕ, nconv = eigs(G'; nev=nev)
+
+    ϕ_funs = BoxFun{P,keytype(P),ComplexF64}[]
+
+    for i in 1:nev
+        ϕi = ϕ[:,i]
+        dict = Dict{keytype(P),ComplexF64}()
+        sizehint!(dict, length(ϕi))
+
+        for j in 1:length(ϕi)
+            dict[gstar.vertices.keylist[j]] = ϕi[j]
+        end
+
+        ϕ_fun = BoxFun{P,keytype(P),ComplexF64}(gstar.vertices.partition, dict)
+        normalize!(ϕ_fun)
+        push!(ϕ_funs, ϕ_fun)
+    end
+
+    return λ, ϕ_funs, nconv
+end


### PR DESCRIPTION
Initial implementation of https://github.com/gaioguys/GAIO.jl/pull/32#issuecomment-663098767.
This PR is in a very early stage. (I'll add a TODO list later here.)

The code
```julia
using StaticArrays

function logistic_map_test()
    g = boxmap(x -> SVector(4*x[1]*(1-x[1])), LinRange(-0.99, 0.99, 15))
    boxset = RegularPartition(Box((0.5,), (0.5,)), 20)[:]

    gstar = TransferOperator(g, boxset)
    boxfun = eigs(gstar)[2][1]

    plot(abs ∘ boxfun)
end
```
produces the following output:
![lmspiky2](https://user-images.githubusercontent.com/1753343/89410999-f7898200-d724-11ea-94b6-8991a6e78683.png)
