### PR TITLE
cleaner and faster map_boxes()

### DIFF
--- a/examples/henon.jl
+++ b/examples/henon.jl
@@ -1,18 +1,20 @@
+using GAIO
+using BenchmarkTools
+
 function henon()
-    n = 20
-
-    points = [
-        [(x, -1.0) for x in LinRange(-1, 1, n)];
-        [(x,  1.0) for x in LinRange(-1, 1, n)];
-        [(-1.0, x) for x in LinRange(-1, 1, n)];
-        [( 1.0, x) for x in LinRange(-1, 1, n)];
-    ]
-
-    f = x -> SVector(1/2 - 2*1.4*x[1]^2 + x[2], 0.3*x[1])
+    n = 10
+    grid = LinRange(-1, 1, n)
+    points = collect(Iterators.product(grid, grid))
+    f(x) = (1/2 - 2*1.4*x[1]^2 + x[2], 0.3*x[1])
 
     g = PointDiscretizedMap(f, points)
-    partition = RegularPartition(Box(SVector(0.0, 0.0), SVector(1.0, 1.0)))
+    domain = Box((0.0, 0.0), (1.0, 1.0))
+    partition = RegularPartition(domain)
     boxset = partition[:]
 
-    return relative_attractor(g, boxset, 20)
+    A = relative_attractor(g, boxset, 26)
+    @btime map_boxes($g,$A)
+    @btime map_boxes_new($g,$A)
 end
+
+henon()

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -5,6 +5,7 @@ using StaticArrays
 using GLFW
 using ModernGL
 using LightGraphs
+using Base.Threads
 
 export Box, BoxSet
 export boxset_empty, subdivide, subdivide!
@@ -13,7 +14,7 @@ export BoxPartition, RegularPartition, TreePartition
 export dimension, depth
 
 export BoxMap, PointDiscretizedMap
-export boxmap
+export boxmap, map_boxes, map_boxes_new
 
 export relative_attractor, unstable_set!, chain_recurrent_set, cover_roots
 


### PR DESCRIPTION
This PR implements a more elegant and yet substantially faster `map_boxes` function.  I have been going back to the drawing board for this since I spent a lot of time on extending the old approach (via the `ParallelBoxIterator`) in the `adaptive_boxmap` branch and yet have been unable to do so.  The current function is almost trivial (and yet easily multi-threaded) and can be trivially extended for `adaptive_boxmap`.  This is meant to be a proof of concept and would need to be extended to mapping to a different `target` and also for the `TransferOperator`.  Would this approach have any serious drawbacks?