### PR TITLE
replacement of BoxPartition by BoxSet in the user API

### DIFF
--- a/examples/attractor.jl
+++ b/examples/attractor.jl
@@ -4,8 +4,8 @@ using GAIO
 a, b = 1.4, 0.3
 f((x,y)) = (1 - a*x^2 + y, b*x)
 
-center, radius = (0, 0), (3, 3)
-P = BoxPartition(Box(center, radius))
+center, radius = [0, 0], (3, 3)
+P = BoxSet(Box(center, radius))
 F = BoxMap(f, P)
 A = relative_attractor(F, P[:], steps = 16)
 

--- a/examples/invariant_measure_1d.jl
+++ b/examples/invariant_measure_1d.jl
@@ -5,7 +5,7 @@ using GAIO
 f(x) = μ.*x.*(1.0.-x)
 
 center, radius = 0.5, 0.5
-P = BoxPartition(Box(center, radius), 256)
+P = BoxSet(Box(center, radius), 256)
 F = BoxMap(f, P; no_of_points=400)
 
 T = TransferOperator(F, P[:])

--- a/examples/invariant_measure_3d.jl
+++ b/examples/invariant_measure_3d.jl
@@ -6,7 +6,7 @@ v((x,y,z)) = (σ*(y-x), ρ*x-y-x*z, x*y-β*z)
 f(x) = rk4_flow_map(v, x)
 
 center, radius = (0,0,25), (30,30,30)
-P = BoxPartition(Box(center, radius), (128,128,128))
+P = BoxSet(Box(center, radius), (128,128,128))
 F = BoxMap(f, P, no_of_points=200)
 
 x = (sqrt(β*(ρ-1)), sqrt(β*(ρ-1)), ρ-1)         # equilibrium

--- a/examples/recurrent_set.jl
+++ b/examples/recurrent_set.jl
@@ -83,7 +83,7 @@ vf = interpolate_v(knotted_v, -3.5, 3.5, 30, 1e-12)
 f(x) = rk4_flow_map(vf, x, step_size = 0.075)
 
 center, radius = (0,0,0), (2,2,2)
-P = BoxPartition(Box(center, radius))
+P = BoxSet(Box(center, radius))
 F = BoxMap(f, P, no_of_points = 200)
 
 C = chain_recurrent_set(F, P[:], steps = 18)

--- a/examples/roots.jl
+++ b/examples/roots.jl
@@ -7,7 +7,7 @@ Dg = x -> ForwardDiff.jacobian(g, x)
 
 dim = 3
 center, radius = zeros(dim), 40*ones(dim)
-P = BoxPartition(Box(center, radius))
+P = BoxSet(Box(center, radius))
 
 R = cover_roots(g, Dg, P[:], steps=dim*8)
 

--- a/examples/unstable_manifold.jl
+++ b/examples/unstable_manifold.jl
@@ -6,7 +6,7 @@ v((x,y,z)) = (σ*(y-x), ρ*x-y-x*z, x*y-β*z)
 f(x) = rk4_flow_map(v, x)
 
 center, radius = (0,0,25), (30,30,30)
-P = BoxPartition(Box(center, radius), (128,128,128))
+P = BoxSet(Box(center, radius), (128,128,128))
 F = BoxMap(f, P)
 
 x = (sqrt(β*(ρ-1)), sqrt(β*(ρ-1)), ρ-1)         # equilibrium

--- a/src/boxmap.jl
+++ b/src/boxmap.jl
@@ -26,6 +26,10 @@ end
 
 BoxMap(map, P::BoxPartition{N,T}; no_of_points::Int=20*N) where {N,T} = BoxMap(map, P.domain, no_of_points=no_of_points) 
 
+function BoxMap(map, B::BoxSet{BoxPartition{N,T},S}; no_of_points::Int=20*N) where {N,T,S}
+    BoxMap(map, B.partition, no_of_points=no_of_points)
+end
+
 function sample_adaptive(Df, center::SVector{N,T}) where {N,T}
     D = Df(center)
     _, σ, Vt = svd(D)

--- a/src/boxset.jl
+++ b/src/boxset.jl
@@ -3,6 +3,18 @@ struct BoxSet{P <: AbstractBoxPartition,S <: AbstractSet}
     set::S
 end
 
+function BoxSet(domain::Box{N,T}, dims::NTuple{N,Int}) where {N,T}
+    P = BoxPartition(domain, dims)
+    return BoxSet(P, Set{keytype(typeof(P))}())
+end
+
+function BoxSet(domain::Box{N,T}) where {N,T}
+    dims = tuple(ones(Int64,N)...)
+    BoxSet(domain, dims)
+end
+
+BoxSet(domain::Box{1,T}, dims::Int) where {T} = BoxPartition(domain, (dims,))
+
 function Base.show(io::IO, boxset::BoxSet) 
     size = length(boxset.set)
     dim = length(boxset.partition.domain.center)
@@ -34,6 +46,11 @@ function Base.getindex(partition::AbstractBoxPartition, points_or_point)
 
     return BoxSet(partition, set)
 end
+
+function Base.getindex(boxset::BoxSet, points_or_point)
+    getindex(boxset.partition, points_or_point)
+end
+
 
 function Base.getindex(partition::AbstractBoxPartition, ::Colon)
     return BoxSet(partition, Set(keys_all(partition)))


### PR DESCRIPTION
adds a contructor for `BoxSet` which enables to remove the necessity for the user to deal with `BoxPartition`s