### PR TITLE
[BugFix] fix type instability

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -39,7 +39,7 @@ end
     expon(ϵ, σ, h, δ) = Int(ceil(log(ϵ * (1/2)^σ)/log(maximum((1 - h, δ)))))
     n = expon(0.2, k, h, 0.1)
 
-    for _ in 1i32:n
+    for _ in 1:n
         Dg = g_jacobian(x)
         x = x - h * (Dg \ g(x))
     end
@@ -50,7 +50,7 @@ end
 function cover_roots(g, Dg, B::BoxSet{<:AbstractBoxPartition{Box{N,T}}}; steps=12) where {N,T}
     domain = B.partition.domain
     for k in 1:steps
-        B = subdivide(B, (k % N) + 1i32)
+        B = subdivide(B, (k % N) + 1)
         f = x -> adaptive_newton_step(g, Dg, x, k)
         F_k = BoxMap(f, domain, no_of_points = 40)
         B = F_k(B)

--- a/src/boxmap_cuda.jl
+++ b/src/boxmap_cuda.jl
@@ -8,11 +8,11 @@ struct BoxMapGPUCache{SZ} end
 
 for T in (:Float64, :J), I in (:Int64, :Int128, :J)
     @eval function Adapt.adapt_structure(
-            a::CUDA.Adaptor, b::BoxPartition{N,$T,$I,D}
-        ) where {N,J,D}
+            a::CUDA.Adaptor, b::BoxPartition{N,$T,$I}
+        ) where {N,J}
 
         Adapt.adapt_storage(a,
-            BoxPartition{N,Float32,Int32,D}(
+            BoxPartition{N,Float32,Int32}(
                 Box{N,Float32}(b.domain.center, b.domain.radius),
                 SVector{N,Float32}(b.left), SVector{N,Float32}(b.scale),
                 SVector{N,Int32}(b.dims), SVector{N,Int32}(b.dimsprod)

--- a/src/partition_regular.jl
+++ b/src/partition_regular.jl
@@ -64,8 +64,8 @@ end
 
 # TODO: replace with overloaded getindex
 @muladd function key_to_box(
-        partition::BoxPartition{N,T}, key::M
-    ) where {N,T,M<:Union{<:Integer, NTuple{N,<:Integer}}}
+        partition::BoxPartition{N,T,I}, key::M
+    ) where {N,T,I,M<:Union{<:Integer, NTuple{N,<:Integer}}}
 
     x_ints = NTuple{N,I}(CartesianIndices(size(partition))[key].I)
     radius = partition.domain.radius ./ partition.dims

--- a/src/partition_regular.jl
+++ b/src/partition_regular.jl
@@ -67,9 +67,10 @@ end
         partition::BoxPartition{N,T}, key::M
     ) where {N,T,M<:Union{<:Integer, NTuple{N,<:Integer}}}
 
+    x_ints = NTuple{N,I}(CartesianIndices(size(partition))[key].I)
     radius = partition.domain.radius ./ partition.dims
     left = partition.domain.center .- partition.domain.radius
-    center = left .+ radius .+ (2 .* radius) .* (CartesianIndices(size(partition))[key].I .- 1)
+    center = @. left + radius + (2 * radius) * (x_ints - 1)
     # start at leftmost box in the partition and move $key boxes right
     return Box{N,T}(center, radius)
 end 


### PR DESCRIPTION
I noticed a small type instability in `key_to_box` that in some cases forces Julia to convert types back and forth. It likely only affects the cuda version. Luckily the fix is only one extra line.

Also a small issue with the Adapt function for BoxPartitions is now fixed.