### PR TITLE
Bugfix in plot.jl + Improve type definition of BoxSet

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,4 +1,4 @@
-function relative_attractor(F::BoxMap, B::BoxSet{<:AbstractBoxPartition{Box{N,T}}}; steps=12) where {N,T}
+function relative_attractor(F::BoxMap, B::BoxSet{Box{N,T}}; steps=12) where {N,T}
     for k = 1:steps
         B = subdivide(B, (k % N) + 1)
         B = B ∩ F(B)
@@ -16,7 +16,7 @@ function unstable_set!(F::BoxMap, B::BoxSet)
     return B
 end
 
-function chain_recurrent_set(F::BoxMap, B::BoxSet{<:AbstractBoxPartition{Box{N,T}}}; steps=12) where {N,T}
+function chain_recurrent_set(F::BoxMap, B::BoxSet{Box{N,T}}; steps=12) where {N,T}
     for k in 1:steps
         B = subdivide(B, (k % N) + 1)
         P = TransferOperator(F, B)
@@ -47,7 +47,7 @@ end
     return x
 end
 
-function cover_roots(g, Dg, B::BoxSet{<:AbstractBoxPartition{Box{N,T}}}; steps=12) where {N,T}
+function cover_roots(g, Dg, B::BoxSet{Box{N,T}}; steps=12) where {N,T}
     domain = B.partition.domain
     for k in 1:steps
         B = subdivide(B, (k % N) + 1)

--- a/src/boxset.jl
+++ b/src/boxset.jl
@@ -6,7 +6,7 @@ Internal data structure to hold sets
 `set`:        set of partition-keys corresponding to the boxes in the set
 
 """
-struct BoxSet{P <: AbstractBoxPartition,S <: AbstractSet}
+struct BoxSet{B,P<:AbstractBoxPartition{B},S<:AbstractSet} <: AbstractSet{B}
     partition::P
     set::S
 end
@@ -16,31 +16,17 @@ function Base.show(io::IO, boxset::BoxSet)
     print(io, "$size-element BoxSet in ", boxset.partition)
 end
 
+Base.show(io::IO, ::MIME"text/plain", boxset::BoxSet) = show(io, boxset)
+
 # TODO: replace with BoxSet(partition)
 function boxset_empty(partition::P) where P <: AbstractBoxPartition
     return BoxSet(partition, Set{keytype(P)}())
 end
 
-function Base.getindex(partition::AbstractBoxPartition, points_or_point)
-    # check if points is only a single point
-    if eltype(points_or_point) <: Number
-        points = (points_or_point,)
-    else
-        points = points_or_point
-    end
-
-    set = Set{keytype(typeof(partition))}()
-    sizehint!(set, length(points))
-
-    for point in points
-        key = point_to_key(partition, point)
-
-        if !isnothing(key)
-            push!(set, key)
-        end
-    end
-
-    return BoxSet(partition, set)
+function Base.getindex(partition::AbstractBoxPartition, points)
+    eltype(points) <: Number && ndims(partition) > 1 && return partition[(points,)]
+    gen = Iterators.filter(!isnothing, (point_to_key(partition, point) for point in points))
+    return BoxSet(partition, Set(gen))
 end
 
 function Base.getindex(partition::AbstractBoxPartition, key::Integer)
@@ -51,12 +37,12 @@ function Base.getindex(partition::AbstractBoxPartition, ::Colon)
     return BoxSet(partition, Set(keys(partition)))
 end
 
-for op in (:union, :intersect, :setdiff)
+for op in (:union, :intersect, :setdiff, :symdiff)
     op! = Symbol(op, :!) 
     boundscheck = quote
         @boundscheck for i in 1:length(sets)-1
             if !(sets[i].partition == sets[i+1].partition)
-                throw(DomainError((sets[i].partition, sets[i+1].partition), "Partitions of boxsets in union do not match."))
+                throw(DomainError((sets[i].partition, sets[i+1].partition), "Partitions of boxsets in operation do not match."))
             end
         end
     end
@@ -74,14 +60,20 @@ for op in (:union, :intersect, :setdiff)
     end
 end
 
+for op in (:issubset, :isdisjoint, :issetequal, :(==))
+    @eval Base.$op(b1::BoxSet, b2::BoxSet) = b1.partition == b2.partition && $op(b1.set, b2.set)
+end
+
 Base.isempty(boxset::BoxSet) = isempty(boxset.set)
+Base.empty!(boxset::BoxSet) = (empty!(boxset.set); boxset)
+Base.copy(boxset::BoxSet) = BoxSet(boxset.partition, copy(boxset.set))
 Base.length(boxset::BoxSet) = length(boxset.set)
 Base.push!(boxset::BoxSet, key) = push!(boxset.set, key)
 Base.sizehint!(boxset::BoxSet, size) = sizehint!(boxset.set, size)
-Base.eltype(::Type{BoxSet{P,S}}) where {P <: AbstractBoxPartition{B},S} where B = B
+Base.eltype(::Type{<:BoxSet{B}}) where B = B
 Base.iterate(boxset::BoxSet, state...) = iterate((key_to_box(boxset.partition, key) for key in boxset.set), state...)
 
-function subdivide(boxset::BoxSet{<:BoxPartition,S}, dim) where {S}
+function subdivide(boxset::BoxSet{B,P,S}, dim) where {B,P<:BoxPartition,S}
     partition = boxset.partition
     box_indices = CartesianIndices(size(partition))
 
@@ -104,7 +96,7 @@ function subdivide(boxset::BoxSet{<:BoxPartition,S}, dim) where {S}
     return BoxSet(partition_subdivided, set)
 end
 
-function subdivide!(boxset::BoxSet{<:TreePartition}, key::NTuple{2,<:Integer})
+function subdivide!(boxset::BoxSet{B,P,S}, key::NTuple{2,<:Integer}) where {B,P<:TreePartition,S}
     !( key in boxset.set ) && throw(KeyError(key))
 
     delete!(boxset.set, key)
@@ -120,7 +112,7 @@ function subdivide!(boxset::BoxSet{<:TreePartition}, key::NTuple{2,<:Integer})
     return boxset
 end
 
-function subdivide(boxset::BoxSet{<:TreePartition})
+function subdivide(boxset::BoxSet{B,P,S}) where {B,P<:TreePartition,S}
     boxset_new = BoxSet(copy(boxset.partition), copy(boxset.set))
 
     for key in boxset.set

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -4,7 +4,6 @@
 
 const default_box_color = :firebrick1
 const default_box_colormap = :jet
-default_projection_func(N) = N <= 3 ? identity : (x -> x[1:3])
 
 """
 plotboxes(boxset::BoxSet)
@@ -43,18 +42,17 @@ All other attributes are taken from MeshScatter.
     )
 end
 
-function MakieCore.plot!(
-        boxes::PlotBoxes{<:Tuple{<:BoxSet{<:AbstractBoxPartition{Box{N,T}}}}}
-    ) where {N,T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxSet{Box{N,T}}}}) where {N,T}
 
     boxset = boxes[1][]
+    d = min(N, 3)
     if isnothing(boxes.projection_func[])
-        boxes.projection_func[] = default_projection_func(N)
+        boxes.projection_func[] = x -> x[1:d]
     end
     q = boxes.projection_func[]
 
-    center = Vector{GeometryBasics.Vec{N, Float32}}(undef, length(boxset))
-    radius = Vector{GeometryBasics.Vec{N, Float32}}(undef, length(boxset))
+    center = Vector{GeometryBasics.Vec{d, Float32}}(undef, length(boxset))
+    radius = Vector{GeometryBasics.Vec{d, Float32}}(undef, length(boxset))
 
     for (i, box) in enumerate(boxset)
         center[i] = q(box.center)
@@ -70,18 +68,17 @@ function MakieCore.plot!(
     )
 end
 
-function MakieCore.plot!(
-        boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{N,T}}}}}
-    ) where {N,T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{N,T}}}}) where {N,T}
 
     boxfun = boxes[1][]
+    d = min(N, 3)
     if isnothing(boxes.projection_func[])
-        boxes.projection_func[] = default_projection_func(N)
+        boxes.projection_func[] = x -> x[1:d]
     end
     q = boxes.projection_func[]
 
-    center = Vector{GeometryBasics.Vec{N, Float32}}(undef, length(boxfun))
-    radius = Vector{GeometryBasics.Vec{N, Float32}}(undef, length(boxfun))
+    center = Vector{GeometryBasics.Vec{d, Float32}}(undef, length(boxfun))
+    radius = Vector{GeometryBasics.Vec{d, Float32}}(undef, length(boxfun))
     colors = Vector{Float32}(undef, length(boxfun))
 
     for (i, (key, value)) in enumerate(boxfun.dict)
@@ -104,9 +101,7 @@ function MakieCore.plot!(
     )
 end
 
-function MakieCore.plot!(
-        boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{2,T}}}}}
-    ) where {T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{2,T}}}}) where {T}
 
     boxfun = boxes[1][]
 
@@ -132,9 +127,7 @@ function MakieCore.plot!(
     )
 end
 
-function MakieCore.plot!(
-        boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{1,T}}}}}
-    ) where {T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{1,T}}}}) where {T}
 
     boxfun = boxes[1][]
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -68,7 +68,7 @@ function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxSet{Box{N,T}}}}) where {N
     )
 end
 
-function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{N,T}}}}) where {N,T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{N,T}}}}}) where {N,T}
 
     boxfun = boxes[1][]
     d = min(N, 3)
@@ -101,7 +101,7 @@ function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{N,T}}}}) where {N
     )
 end
 
-function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{2,T}}}}) where {T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{2,T}}}}}) where {T}
 
     boxfun = boxes[1][]
 
@@ -127,7 +127,7 @@ function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{2,T}}}}) where {T
     )
 end
 
-function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{Box{1,T}}}}) where {T}
+function MakieCore.plot!(boxes::PlotBoxes{<:Tuple{<:BoxFun{<:AbstractBoxPartition{Box{1,T}}}}}) where {T}
 
     boxfun = boxes[1][]
 


### PR DESCRIPTION
There was asmall bug in plot.jl that made plotting in dimensions >3 act incorrectly. 

Also, I added the box-type to the parameters of BoxSet:

```julia
struct BoxSet{B,P<:AbstractBoxPartition{B},S<:AbstractSet} <: AbstractSet{B}
    partition::P
    set::S
end
```

This makes code in algorithms.jl a bit prettier, and will make the next PR on TransferOperators more elegant. 
