### PR TITLE
Add `BoxSet` constructor, fix bad url in `docs | latest` button, ensure consistent one-based indexing in `BoxPartition`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GAIO.jl is a Julia package for set oriented computations.  Sets are represented 
 
 ## Documentation
 
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://gaioguys.github.io/GAIO.jl/dev/)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://gaioguys.github.io/GAIO.jl/)
 
 ## Installation
 

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -23,7 +23,8 @@ using Base.Iterators: Stateful, take
 using MakieCore
 using MakieCore: @recipe
 
-export Box, volume
+export Box
+export volume, vertices
 
 export AbstractBoxPartition, BoxPartition, TreePartition
 export depth, key_to_box, point_to_key, tree_search

--- a/src/box.jl
+++ b/src/box.jl
@@ -40,6 +40,10 @@ end
 
 Box(center, radius) = Box{length(center), promote_type(F, eltype(center), eltype(radius))}(center, radius)
 
+function Base.show(io::IO, box::B) where {B<:Box} 
+    print(io, "$(B):\n    center = $(box.center),\n    radii = $(box.radius)")
+end
+
 Base.in(point, box::Box) = all(box.center .- box.radius  .<=  point  .<  box.center .+ box.radius)
 Base.:(==)(b1::Box, b2::Box) = b1.center == b2.center && b1.radius == b2.radius
 

--- a/src/box.jl
+++ b/src/box.jl
@@ -48,6 +48,14 @@ Computes the volume of a box.
 """
 volume(box::Box) = prod(2 .* box.radius)
 
-function Base.show(io::IO, box::Box) 
-    print(io, "Box:\n    center = $(box.center),\n    radii = $(box.radius)")
+"""
+    vertices(box)
+    vertices(center, radius)
+
+Return an iterator over the vertices of a `box = Box(center, radius)`. 
+"""
+function vertices(center::SVNT{N,T}, radius::SVNT{N,T}) where {N,T}
+    I = CartesianIndices(ntuple(_->-1:2:1, N))
+    (@muladd(center .+ radius .* Tuple(i)) for i in I)
 end
+vertices(box::Box) = vertices(box.center, box.radius)

--- a/src/boxmap.jl
+++ b/src/boxmap.jl
@@ -14,12 +14,14 @@ Fields:
 * `map`:              map that defines the dynamical system.
 * `domain`:           domain of the map, `B`.
 * `domain_points`:    the spread of test points to be mapped forward in intersection algorithms.
-                    (scaled to fit a box with unit radii)
+                      Must have the signature `domain_points(center, radius)` and return 
+                      an iterator of points within `Box(center, radius)`. 
 * `image_points`:     the spread of test points for comparison in intersection algorithms.
-                    (scaled to fit a box with unit radii)
+                      Must have the signature `domain_points(center, radius)` and return 
+                      an iterator of points within `Box(center, radius)`. 
 * `acceleration`:     Whether to use optimized functions in intersection algorithms.
-                    Accepted values: `nothing`, `Val(:cpu)`, `Val(:gpu)`.
-                    `Val(:gpu)` does nothing unless you have a CUDA capable gpu.
+                      Accepted values: `nothing`, `BoxMapCPUCache`, `BoxMapGPUCache`.
+                      `BoxMapGPUCache` does nothing unless you have a CUDA capable gpu.
 
 .
 """

--- a/src/boxset.jl
+++ b/src/boxset.jl
@@ -46,6 +46,7 @@ function boxset_empty(partition::P) where P <: AbstractBoxPartition
 end
 
 """
+* getindex constructors:
 * set of all boxes in `P`:
 ```julia
 B = P[:]    
@@ -64,8 +65,36 @@ Return a subset of the partition `P` based on the second argument.
 """
 function Base.getindex(partition::AbstractBoxPartition, points)
     eltype(points) <: Number && ndims(partition) > 1 && return partition[(points,)]
-    gen = Iterators.filter(!isnothing, (point_to_key(partition, point) for point in points))
+    eltype(points) <: Box && return cover_boxes(partition, points)
+    gen = (key for key in (point_to_key(partition, point) for point in points) if !isnothing(key))
     return BoxSet(partition, Set(gen))
+end
+
+"""
+    cover_boxes(partition::BoxPartition, boxes)
+
+Return a covering of an iterator of `Box`es using `Box`es from `partition`. 
+Only covers the part of `boxes` which lies within `partition.domain`. 
+"""
+function cover_boxes(partition::BoxPartition{N,T,I}, boxes) where {N,T,I}
+    keys = Set{I}()
+    vertex_keys = Matrix{I}(undef, N, 2)
+    for box_in in boxes
+        box = Box{N,T}(box_in.center, box_in.radius .- 2*eps(T))
+        vertex_keys[:, 1] .= vertex_keys[:, 2] .= bounded_point_to_ints(partition, box.center)
+        for point in vertices(box)
+            ints = bounded_point_to_ints(partition, point)
+            vertex_keys[:, 1] .= min.(vertex_keys[:, 1], ints)
+            vertex_keys[:, 2] .= max.(vertex_keys[:, 2], ints)
+        end
+        C = CartesianIndices(ntuple(i -> vertex_keys[i, 1] : vertex_keys[i, 2], Val(N)))
+        for ind in C
+            key = ints_to_key(partition, ind.I)
+            isnothing(key) && @error "Indexing went wrong somehow. Please open an issue with an MWE" ind.I key
+            union!(keys, key)
+        end
+    end
+    return BoxSet(partition, keys)
 end
 
 function Base.getindex(partition::AbstractBoxPartition, key::Integer)

--- a/src/partition_tree.jl
+++ b/src/partition_tree.jl
@@ -86,7 +86,7 @@ function tree_search(tree::TreePartition{N,T}, point) where {N,T}
         ints_next = unsafe_point_to_ints(regular_partitions[current_depth+2], point)
 
         # cycles through components, decides whether point lies in an even or odd box in that component
-        point_is_left = iseven(ints_next[(current_depth % N) + 1])
+        point_is_left = iseven(ints_next[(current_depth % N) + 1] - 1)
 
         
         node = tree.nodes[node_idx]
@@ -102,7 +102,7 @@ function tree_search(tree::TreePartition{N,T}, point) where {N,T}
         current_depth += 1
     end
 
-    key = (current_depth, sum(ints .* regular_partitions[current_depth+1].dimsprod) + 1)
+    key = (current_depth, ints_to_key(regular_partitions[current_depth+1], ints))
 
     return key, node_idx
 end

--- a/test/boxmap.jl
+++ b/test/boxmap.jl
@@ -15,33 +15,6 @@ using Test
     @testset "basics" begin
         @test typeof(g) <: SampledBoxMap
         partition = BoxPartition(domain, (32,32))
-        p1 = (0.0, 0.0)
-        p2 = (0.5, 0.0)
-        p3 = (0.0, -0.5)
-        boxset = partition[(p1, p2, p3)]
-        # re-implement a straight forward box map to have a ground truth
-        # terrible implementation in any real scenario
-        mapped_points = []
-        for box in boxset
-            push!(mapped_points, f(box.center .- box.radius))
-            push!(mapped_points, f(box.center .+ box.radius))
-            x = f((box.center[1] .- box.radius[1], box.center[2] .+ box.radius[2]))
-            push!(mapped_points, x)
-            y = f((box.center[1] .+ box.radius[1], box.center[2] .- box.radius[2]))
-            push!(mapped_points, y)
-        end
-        image = partition[mapped_points]
-        full_boxset = partition[:]
-        mapped1 = g(boxset)
-
-        @test !isempty(boxset) && !isempty(image)
-        # easiest way right now to check for equality
-        @test length(union(image, mapped1)) == length(intersect(image, mapped1))
-    end
-    g = PointDiscretizedMap(f, domain, test_points, Val(:cpu))
-    @testset "basics with :cpu" begin
-        @test typeof(g) <: SampledBoxMap
-        partition = BoxPartition(domain, (32,32))
         p1 = SVector(0.0, 0.0)
         p2 = SVector(0.5, 0.0)
         p3 = SVector(0.0, -0.5)

--- a/test/boxset.jl
+++ b/test/boxset.jl
@@ -44,6 +44,12 @@ using Test
             @test any(box -> p3 ∈ box, box_set)
             @test any(box -> p4 ∈ box, box_set)
         end
+        @testset "boxsets created on boxes" begin
+            boxes = [GAIO.point_to_box(partition, p) for p in (p1, p2, p3, p4)]
+            box_set = partition[boxes]
+            box_set_points = partition[(p1, p2, p3, p4)]
+            @test box_set == box_set_points
+        end
         @testset "set operations" begin
             p1_box_set = partition[p1]
             p1p2_box_set = partition[(p1, p2)]


### PR DESCRIPTION
I'm preparing the update to FLoops.jl, and have some small changes that are required for that future PR. Also some docstrings had typos.

Adds a constructor to allow `Boxset`s to be made using arrays of boxes, ie
```julia
S = [Box(center_1, radius_1), Box(center_2, radius_2), Box(center_3, radius_3)]
P = BoxPartition(Box(center_1, radius_1 .+ radius_2 .+ radius_3), (100,100,100))
B = P[S]
```
returns a covering of `S` using boxes from `P`. 

Also, some sections in `partition_regular.jl` use zero-based indexing, which caused some confusing errors. They are now fixed. `partition_tree.jl` still uses zero-based indexing and one-based indexing together; I'm considering a rework on that file. 