### PR TITLE
Refactoring SampledBoxMap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "GAIO"
 uuid = "33d280d1-ac47-4b0f-9c2e-fa6a385d0226"
 authors = ["The GAIO.jl Team"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -17,4 +18,5 @@ MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -10,6 +10,7 @@ using Graphs
 using ForwardDiff
 using Arpack
 using Base.Threads
+using FLoops
 using Base: unsafe_trunc
 using MuladdMacro
 using HostCPUFeatures
@@ -17,6 +18,7 @@ using SIMD
 using Adapt
 using CUDA
 using Base.Iterators: Stateful, take
+using SplittablesBase
 
 # using GLMakie
 # using WGLMakie
@@ -24,7 +26,7 @@ using MakieCore
 using MakieCore: @recipe
 
 export Box
-export volume, vertices
+export volume, center, vertices
 
 export AbstractBoxPartition, BoxPartition, TreePartition
 export depth, key_to_box, point_to_key, tree_search

--- a/src/box.jl
+++ b/src/box.jl
@@ -63,3 +63,42 @@ function vertices(center::SVNT{N,T}, radius::SVNT{N,T}) where {N,T}
     (@muladd(center .+ radius .* Tuple(i)) for i in I)
 end
 vertices(box::Box) = vertices(box.center, box.radius)
+
+"""
+    center(b::Box)
+    center(center, radius)
+
+Return the center of a box as an iterable. 
+Default function for `image_points` in `SampledBoxMap`s. 
+"""
+center(center, radius) = (center,)
+center(box::Box) = (box.center,)
+
+"""
+    rescale(box, point::Union{<:StaticVector{N,T}, <:NTuple{N,T}})
+    rescale(center, radius, point::Union{<:StaticVector{N,T}, <:NTuple{N,T}})
+
+Scale a `point` within the unit box ``[-1, 1]^N`` 
+to lie within `box = Box(center, radius)`. 
+"""
+rescale(center, radius, point::SVNT{N,T}) where {N,T} = @muladd center .+ point .* radius
+rescale(box::Box, points) = rescale(box.center, box.radius, points)
+
+"""
+    rescale(center, radius, points)
+
+Return an iterable which calls
+`rescale(center, radius, point)` for each point in `points`. 
+"""
+rescale(center, radius, points) = (rescale(center, radius, point) for point in points)
+
+"""
+    rescale(points)
+
+Return a function 
+```julia
+(center, radius) -> rescale(center, radius, points)
+```
+Used in `domain_points` for `BoxMap`, `PointDiscretizedMap`. 
+"""
+rescale(points) = (center, radius) -> rescale(center, radius, points)

--- a/src/boxmap_cuda.jl
+++ b/src/boxmap_cuda.jl
@@ -90,7 +90,7 @@ function TransferOperator(
         available_array_memory() ÷ (sizeof(Int32) * 10 * (N + 1) * np)
     ) ÷ 2
     for i in 0:SZ2:max(0, length(boxlist)-SZ2)
-        in_keys = CuArray{Int32,1}(boxlist.keylist[i+1:i+stride])
+        in_keys = CuArray{Int32,1}(boxlist.keylist[i+1:i+SZ2])
         nk = Int32(length(in_keys))
         out_keys = CuArray{Tuple{Int32,Int32},1}(undef, nk * np)
         launch_kernel_then_sync!(nk * np, TransferOperator_kernel!, g.map, P, points, in_keys, out_keys)
@@ -103,7 +103,7 @@ function TransferOperator(
         end
         CUDA.unsafe_free!(in_keys); CUDA.unsafe_free!(out_keys)
     end
-    delete!(edges, (0,0))
+    delete!(edges, (0.,0.))
     return TransferOperator(boxlist, edges)
 end
 

--- a/src/boxmap_cuda.jl
+++ b/src/boxmap_cuda.jl
@@ -4,71 +4,97 @@ struct NumLiteral{T} end
 Base.:(*)(x, ::Type{NumLiteral{T}}) where T = T(x)
 const i32, ui32 = NumLiteral{Int32}, NumLiteral{UInt32}
 
-struct BoxMapGPUCache{SZ} end
+struct BoxMapGPUCache end
 
 function PointDiscretizedMap(map, domain::Box{N,T}, points, ::Val{:gpu}) where {N,T}
     points_vec = cu(points)
-    maxsize = CUDA.available_memory() ÷ (N * sizeof(Int32) * 2)
-    return PointDiscretizedMap(map, domain, points_vec, BoxMapGPUCache{maxsize}())
+    return PointDiscretizedMap(map, domain, points_vec, BoxMapGPUCache())
 end
 
-for (key, val) in Dict(
-            :map_boxes => :(!isnothing(hit) ? hit : 0i32), 
-            :TransferOperator => :(!isnothing(hit) ? (key,hit) : (0i32,0i32))
-        )
-
-    kernel = Symbol(key, :_kernel!)
-    @eval @muladd function $kernel(G, keys, points, out_keys, P, np, nk)
-        ind = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x - 1i32
-        stride = gridDim().x * blockDim().x
-        len = nk * np - 1i32
-        for i in ind : stride : len
-            m, n = divrem(i, np) .+ 1i32
-            key  = keys[n]
-            box  = key_to_box(P, key)
-            c, r = box.center, box.radius
-            p    = points[m]
-            fp   = G(@. p * r + c)
-            hit  = point_to_key(P, fp)
-            out_keys[i+1] = $val
-        end
+function map_boxes_kernel!(g, P, domain_points, in_keys, out_keys)
+    nk, np = Int32.((length(in_keys), length(domain_points)))
+    ind = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x #- 1i32
+    stride = gridDim().x * blockDim().x
+    len = nk * np #- 1i32
+    for i in ind : stride : len
+        m, n = Int32.(CartesianIndices((np, nk))[i].I)
+        p    = domain_points[m]
+        key  = in_keys[n]
+        box  = key_to_box(P, key)
+        c, r = box.center, box.radius
+        fp   = g(@muladd p .* r .+ c)
+        hit  = point_to_key(P, fp)
+        out_keys[i] = isnothing(hit) ? 0i32 : hit
     end
 end
 
-function map_boxes(g::SampledBoxMap{<:BoxMapGPUCache{SZ}}, source::BoxSet) where SZ
+function TransferOperator_kernel!(g, P, domain_points, in_keys, out_keys)
+    nk, np = Int32.((length(in_keys), length(domain_points)))
+    ind = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x #- 1i32
+    stride = gridDim().x * blockDim().x
+    len = nk * np #- 1i32
+    for i in ind : stride : len
+        m, n = Int32.(CartesianIndices((np, nk))[i].I)
+        p    = domain_points[m]
+        key  = in_keys[n]
+        box  = key_to_box(P, key)
+        c, r = box.center, box.radius
+        fp   = g(@muladd p .* r .+ c)
+        hit  = point_to_key(P, fp)
+        out_keys[i] = isnothing(hit) ? (0i32, 0i32) : (key, hit)
+    end
+end
+
+function map_boxes(
+        g::SampledBoxMap{C,N,T,F,D,typeof(center)}, source::BoxSet{B,Q,S}
+    ) where {C<:BoxMapGPUCache,N,T,F,D,B,Q,S}
+
     P, keys = source.partition, Stateful(source.set)
-    points = g.domain_points(P.domain.center, P.domain.radius)
-    image = BoxSet(P, Set{Int32}())
+    p = ensure_implemented(g, P)
+    np = length(p)
+    image = S()
     while !isnothing(keys.nextvalstate)
-        stride = min(SZ, length(keys))
+        stride = min(
+            length(keys),
+            available_array_memory() ÷ (sizeof(Int32) * 10 * (N + 1) * np)
+        )
         in_keys = CuArray{Int32,1}(collect(take(keys, stride)))
-        nk, np = Int32(length(in_keys)), Int32(length(points))
+        nk = length(in_keys)
         out_keys = CuArray{Int32,1}(undef, nk * np)
-        launch_kernel_then_sync!(nk * np, map_boxes_kernel!, g.map, in_keys, points, out_keys, P, nk, np)
+        launch_kernel_then_sync!(
+            nk * np, map_boxes_kernel!, 
+            g.map, P, p, in_keys, out_keys
+        )
         out_cpu = Array{Int32,1}(out_keys)
-        y = Set(out_cpu)
-        delete!(y, 0i32)
-        union!(image, BoxSet(P, y))
+        union!(image, out_cpu)
         CUDA.unsafe_free!(in_keys); CUDA.unsafe_free!(out_keys)
     end
-    return image
+    delete!(image, 0i32)
+    return BoxSet(P, image)
 end
 
-function TransferOperator(g::SampledBoxMap{<:BoxMapGPUCache{SZ}}, source::BoxSet{<:BoxPartition}) where SZ
-    P, SZ2 = source.partition, SZ ÷ 2
-    points = g.domain_points(P.domain.center, P.domain.radius)
+function TransferOperator(
+        g::SampledBoxMap{C,N,T,F,D,typeof(center)}, source::BoxSet{B,Q,S}
+    ) where {C<:BoxMapGPUCache,N,T,F,D,B,Q,S}
+
+    P = source.partition
+    points = ensure_implemented(g, P)
+    np = length(points)
+    inv_n = 1. / np
     edges = Dict{Tuple{Int,Int},Float64}()
     boxlist = BoxList(P, collect(Int32, source.set))
     key_to_index = invert_vector(boxlist.keylist)
     key_to_index[0i32] = 0
+    SZ2 = min(
+        length(boxlist),
+        available_array_memory() ÷ (sizeof(Int32) * 10 * (N + 1) * np)
+    ) ÷ 2
     for i in 0:SZ2:max(0, length(boxlist)-SZ2)
-        stride = min(SZ2, length(boxlist)-i)
         in_keys = CuArray{Int32,1}(boxlist.keylist[i+1:i+stride])
-        nk, np = Int32(length(in_keys)), Int32(length(points))
+        nk = Int32(length(in_keys))
         out_keys = CuArray{Tuple{Int32,Int32},1}(undef, nk * np)
-        launch_kernel_then_sync!(nk * np, TransferOperator_kernel!, g.map, in_keys, points, out_keys, P, nk, np)
+        launch_kernel_then_sync!(nk * np, TransferOperator_kernel!, g.map, P, points, in_keys, out_keys)
         out_cpu = Array{Tuple{Int32,Int32},1}(out_keys)
-        inv_n = 1. / np
         for (key, hit) in out_cpu
             if hit in source.set
                 e = (key_to_index[key], key_to_index[hit])
@@ -82,14 +108,24 @@ function TransferOperator(g::SampledBoxMap{<:BoxMapGPUCache{SZ}}, source::BoxSet
 end
 
 # helper + compatibility functions
-function launch_kernel_then_sync!(n, kernel, args...)
+function launch_kernel!(n, kernel, args...)
     compiled_kernel! = @cuda launch=false kernel(args...)
     config  = launch_configuration(compiled_kernel!.fun)
     threads = min(n, config.threads)
     blocks  = cld(n, threads)
     compiled_kernel!(args...; threads, blocks)
+    return
+end
+
+function launch_kernel_then_sync!(n, kernel, args...)
+    launch_kernel!(n, kernel, args...)
     CUDA.synchronize()
     return
+end
+
+function available_array_memory()
+    m = CUDA.MemoryInfo()
+    return m.free_bytes + m.pool_reserved_bytes
 end
 
 for adaptor in (CUDA.CuArrayAdaptor, CUDA.Adaptor), T in (:Float64, :J), I in (:Int64, :Int128, :J)
@@ -109,7 +145,21 @@ end
 
 function Adapt.adapt_structure(
         ::CUDA.CuArrayAdaptor, x::V
-    ) where {N,Float64,V<:AbstractArray{<:SVNT{N,Float64}}}
+    ) where {N,F<:AbstractFloat,V<:AbstractArray{<:SVNT{N,F}}}
 
     CuArray{SVector{N,Float32},1}(x)
+end
+
+function ensure_implemented(g, P)
+    points = g.domain_points(P.domain.center, P.domain.radius)
+
+    if points isa AbstractArray
+        p = cu(points)
+    elseif points isa Base.Generator{<:AbstractArray}
+        p = cu(points.iter)
+    else
+        @error "Test point sampling techniques other than Monte-Carlo not implemented"
+    end
+
+    return p
 end

--- a/src/boxmap_simd.jl
+++ b/src/boxmap_simd.jl
@@ -1,8 +1,18 @@
 struct BoxMapCPUCache{simd,V,W}
     idx_base::SIMD.Vec{simd,Int}
-    temp_points::V
-    temp_points_vec::W
+    temp_vec::V
+    temp_points::W
 end
+
+function BoxMapCPUCache(N, T)
+    simd = Int(pick_vector_width(T))
+    idx_base = SIMD.Vec{simd,Int}(ntuple( i -> N*(i-1), Val(simd) ))
+    temp_vec = Vector{T}(undef, N*simd*nthreads())
+    temp_points = reinterpret(SVector{N,T}, temp_vec)
+    BoxMapCPUCache(idx_base, temp_vec, temp_points)
+end
+
+BoxMapCPUCache(::Box{N,T}) where {N,T} = BoxMapCPUCache(N, T)
 
 function PointDiscretizedMap(map, domain::Box{N,T}, points, ::Val{:cpu}) where {N,T}
     n, simd = length(points), Int(pick_vector_width(T))
@@ -10,12 +20,9 @@ function PointDiscretizedMap(map, domain::Box{N,T}, points, ::Val{:cpu}) where {
         throw(DimensionMismatch("Number of test points $n is not divisible by $T SIMD capability $simd"))
     end
     gathered_points = tuple_vgather(points, simd)
-    domain_points(center, radius) = gathered_points
-    image_points(center, radius) = center
-    idx_base = SIMD.Vec{simd,Int}(ntuple( i -> N*(i-1), Val(simd) ))
-    temp_points = Vector{T}(undef, N*simd*nthreads())
-    temp_points_vec = reinterpret(SVector{N,T}, temp_points)
-    return SampledBoxMap(map, domain, domain_points, image_points, BoxMapCPUCache(idx_base, temp_points, temp_points_vec))
+    domain_points = rescale(gathered_points)
+    image_points = center
+    return SampledBoxMap(map, domain, domain_points, image_points, BoxMapCPUCache(domain))
 end
 
 function sample_adaptive(Df, center::SVector{N,T}, ::Val{simd}) where {N,T,simd} 
@@ -38,47 +45,37 @@ function sample_adaptive(Df, center::SVector{N,T}, ::Val{simd}) where {N,T,simd}
 end
 
 function AdaptiveBoxMap(f, domain::Box{N,T}, accel::Val{:cpu}) where {N,T}
-    Df = x -> ForwardDiff.jacobian(f, x)
+    Df(x) = ForwardDiff.jacobian(f, x)
     simd = Int(pick_vector_width(T))
-    domain_points(center, radius) = sample_adaptive(Df, center, Val(simd))
-
-    vertices = Array{SVector{N,T}}(undef, ntuple(k->2, N))
-    for i in CartesianIndices(vertices)
-        vertices[i] = ntuple(k -> (-1.0)^i[k], N)
-    end
-    # calculates the vertices of each box
-    image_points(center, radius) = vertices
-
-    idx_base = SIMD.Vec{simd,Int}(ntuple( i -> N*(i-1), Val(simd) ))
-    temp_points = Vector{T}(undef, N*simd*nthreads())
-    temp_points_vec = reinterpret(SVector{N,T}, temp_points)
-    
-    return SampledBoxMap(f, domain, domain_points, image_points, BoxMapCPUCache(idx_base, temp_points, temp_points_vec))
+    domain_points(center, radius) = rescale(center, radius, sample_adaptive(Df, center, Val(simd)))
+    image_points = vertices
+    return SampledBoxMap(f, domain, domain_points, image_points, BoxMapCPUCache(domain))
 end
 
-@inbounds function map_boxes(g::SampledBoxMap{<:BoxMapCPUCache{simd},N}, source::BoxSet) where {simd,N}
-    P, keys = source.partition, collect(source.set)
-    image = [ Set{eltype(keys)}() for _ in 1:nthreads() ]
+@inbounds @muladd function map_boxes(g::SampledBoxMap{<:BoxMapCPUCache{simd},N}, source::BoxSet{B,Q,S}) where {simd,N,B,Q,S}
+    P = source.partition
     idx_base, temp_vec, temp_points = g.acceleration
-    @threads for key in keys
-        tid  = (threadid() - 1) * simd
-        idx  = idx_base + tid * N
+    @floop for box in source
+        tid = (threadid() - 1) * simd
+        idx = idx_base + tid * N
         mapped_points = @view temp_points[tid+1:tid+simd]
-        box  = key_to_box(P, key)
         c, r = box.center, box.radius
-        points = g.domain_points(c, r)
-        for p in points
-            fp = g.map(@muladd p .* r .+ c)
+        for p in g.domain_points(c, r)
+            fp = g.map(p)
             tuple_vscatter!(temp_vec, fp, idx)
             for q in mapped_points
-                hit = point_to_key(P, q)
-                if !isnothing(hit)
-                    push!(image[threadid()], hit)
+                hitbox = point_to_box(P, q)
+                isnothing(hitbox) && continue
+                r = hitbox.radius
+                for ip in g.image_points(q, r)
+                    hit = point_to_key(P, ip)
+                    isnothing(hit) && continue
+                    @reduce(image = union!(S(), hit))
                 end
             end
         end
     end
-    return BoxSet(P, union(image...))
+    return BoxSet(P, image)
 end
 
 @inbounds function TransferOperator(g::SampledBoxMap{<:BoxMapCPUCache{simd},N}, source::BoxSet{<:BoxPartition}) where {simd,N}
@@ -97,7 +94,7 @@ end
         points = g.domain_points(c, r)
         inv_n = 1. / (length(points) * simd)
         for p in points
-            fp = g.map(@muladd p .* r .+ c)
+            fp = g.map(p)
             tuple_vscatter!(temp_vec, fp, idx)
             for q in mapped_points
                 hit = point_to_key(P, q)
@@ -113,18 +110,18 @@ end
 end
 
 # helper + compatibility functions
-function Base.show(io::IO, g::SampledBoxMap{<:BoxMapCPUCache{simd}}) where {simd}
+function Base.show(io::IO, g::SampledBoxMap{C}) where {simd,C<:BoxMapCPUCache{simd}}
     center, radius = g.domain.center, g.domain.radius
     n = length(g.domain_points(center, radius)) * simd
     print(io, "BoxMap with $(n) sample points")
 end
 
-Base.iterate(c::BoxMapCPUCache) = (c.idx_base, Val(:temp_points))
-Base.iterate(c::BoxMapCPUCache, ::Val{:temp_points}) = (c.temp_points, Val(:temp_points_vec))
-Base.iterate(c::BoxMapCPUCache, ::Val{:temp_points_vec}) = (c.temp_points_vec, Val(:done))
+Base.iterate(c::BoxMapCPUCache) = (c.idx_base, Val(:temp_vec))
+Base.iterate(c::BoxMapCPUCache, ::Val{:temp_vec}) = (c.temp_vec, Val(:temp_points))
+Base.iterate(c::BoxMapCPUCache, ::Val{:temp_points}) = (c.temp_points, Val(:done))
 Base.iterate(c::BoxMapCPUCache, ::Val{:done}) = nothing
 
-function tuple_vgather(
+Base.@propagate_inbounds function tuple_vgather(
         v::V, idx::SIMD.Vec{simd,Int}# = SIMD.Vec(ntuple( i -> N*(i-1), simd ))
     ) where {N,T,simd,V<:AbstractArray{<:SVNT{N,T}}}
 
@@ -133,7 +130,7 @@ function tuple_vgather(
     return vo
 end
 
-@inline function tuple_vgather(
+Base.@propagate_inbounds function tuple_vgather(
         v::V, simd::Integer
     ) where {N,T,V<:AbstractArray{<:SVNT{N,T}}}
 
@@ -151,7 +148,7 @@ end
     return vo
 end
 
-@inline function tuple_vgather_lazy(
+Base.@propagate_inbounds function tuple_vgather_lazy(
         v::V, simd
     ) where {N,T,V<:AbstractArray{<:SVNT{N,T}}}
     
@@ -169,7 +166,7 @@ end
     return vr
 end
 
-function tuple_vscatter!(
+Base.@propagate_inbounds function tuple_vscatter!(
         vo::VO, vi::VI, idx::SIMD.Vec{simd,I}
     ) where {N,T,simd,VO<:AbstractArray{T},VI<:SVNT{N,SIMD.Vec{simd,T}},I<:Integer}
     
@@ -178,7 +175,7 @@ function tuple_vscatter!(
     end
 end
 
-function tuple_vscatter!(
+Base.@propagate_inbounds function tuple_vscatter!(
         vo::VO, vi::VI
     ) where {N,T,simd,VO<:AbstractArray{T},VI<:AbstractArray{<:SVNT{N,SIMD.Vec{simd,T}}}}
 

--- a/src/boxset.jl
+++ b/src/boxset.jl
@@ -47,19 +47,19 @@ end
 
 """
 * getindex constructors:
-* set of all boxes in `P`:
-```julia
-B = P[:]    
-```
-* cover the point `x`, or points `x = [x_1, x_2, x_3] # etc ...` using boxes from `P`
-```julia
-B = P[x]
-```    
-* a covering of `S` using boxes from `P`
-```julia
-S = [Box(center_1, radius_1), Box(center_2, radius_2), Box(center_3, radius_3)] # etc... 
-B = P[S]    
-```
+    * set of all boxes in `P`:
+    ```julia
+    B = P[:]    
+    ```
+    * cover the point `x`, or points `x = [x_1, x_2, x_3] # etc ...` using boxes from `P`
+    ```julia
+    B = P[x]
+    ```    
+    * a covering of `S` using boxes from `P`
+    ```julia
+    S = [Box(center_1, radius_1), Box(center_2, radius_2), Box(center_3, radius_3)] # etc... 
+    B = P[S]    
+    ```
 
 Return a subset of the partition `P` based on the second argument. 
 """
@@ -146,6 +146,13 @@ Base.push!(boxset::BoxSet, key) = push!(boxset.set, key)
 Base.sizehint!(boxset::BoxSet, size) = sizehint!(boxset.set, size)
 Base.eltype(::Type{<:BoxSet{B}}) where B = B
 Base.iterate(boxset::BoxSet, state...) = iterate((key_to_box(boxset.partition, key) for key in boxset.set), state...)
+SplittablesBase.amount(boxset::BoxSet) = SplittablesBase.amount(boxset.set)
+
+function SplittablesBase.halve(boxset::BoxSet)
+    P = boxset.partition
+    left, right = SplittablesBase.halve(boxset.set)
+    ((key_to_box(P, key) for key in left), (key_to_box(P, key) for key in right))
+end
 
 function subdivide(boxset::BoxSet{B,P,S}, dim) where {B,P<:BoxPartition,S}
     partition = boxset.partition

--- a/src/transfer_operator.jl
+++ b/src/transfer_operator.jl
@@ -64,7 +64,7 @@ function invert_vector(x::AbstractVector{T}) where T
 end
 
 # TODO: this code is generally incorrect. only valid for BoxPartition and special choices of points
-function TransferOperator(g::SampledBoxMap, boxset::BoxSet)
+function TransferOperator(g::SampledBoxMap, boxset::BoxSet{BB,QQ,SS}) where {BB,QQ,SS}
     Q = g.domain    
     n = length(g.domain_points(Q.center, Q.radius))
     P = boxset.partition


### PR DESCRIPTION
This is the update to using FLoops.jl. There are some breaking changes:
* `domain_points` and `image_points` for `SampledBoxMap`s now return points _within the box_. The caller must ensure that this holds, eg by using the new convenience functions `center(b::Box)` and `vertices(b::Box)`, also `rescale(center, radius, points)` which returns a generator that rescales points within `[-1,1]^N` to be within `Box(center, radius)`. Constructors such as `BoxMap`, `PointDiscretizedMap`, `AdaptiveBoxMap` use these functions. 
* `map_boxes` now uses `@floop`. Every `boxset.set` must implement a `SplittablesBase.halve` method. The base julia `Set` has this, and methods for `OrderedSet`, `BitSet` will be added in the next PR through SplitOrderedCollections.jl
* There is a temporary working `TransferOperator` for gpu boxmaps, but it is not very elegant or efficient. The "real" gpu `TransferOperator` method will be added in the next PR, which is the `TransferOperator` refactor. 