### PR TITLE
Unify `BoxMap` interface + general `box_dimension` function

### DIFF
--- a/examples/advanced/almost_invariant_sets.jl
+++ b/examples/advanced/almost_invariant_sets.jl
@@ -8,7 +8,7 @@ f(x) = rk4_flow_map(v, x, 0.05, 5)
 center, radius = (0,0,0), (12,3,20)
 Q = Box(center, radius)
 P = BoxPartition(Q, (128,128,128))
-F = BoxMap(:montecarlo, f, P, no_of_points=200)
+F = BoxMap(:montecarlo, f, P, n_points=200)
 
 # computing the attractor by covering the 2d unstable manifold
 # of two equilibria

--- a/examples/advanced/dadras_system.jl
+++ b/examples/advanced/dadras_system.jl
@@ -22,7 +22,7 @@ v((x,y,z,w)) = (a*x-y*z+w, x*z-b*y, x*y-c*z+x*w, -y)
 f(x) = rk4_flow_map(v, x, 0.01, 10)
 
 domain = Box((0,0,0,0), (250,150,200,25))
-F = BoxMap(:montecarlo, f, domain, no_of_points=1024)
+F = BoxMap(:interval, f, domain, n_subintervals=(8,8,8))
 
 P = BoxPartition(domain, (96,96,96,96))
 S = cover(P, Box((0,0,0,0), (0.1,0.1,0.1,0.1)))

--- a/examples/boxmaps.jl
+++ b/examples/boxmaps.jl
@@ -32,17 +32,17 @@ p = plot!(p, boundary[:, 1], boundary[:, 2], linewidth=4, fill=(0, RGBA(0.,0.,1.
 # Plot the discretized images, using various discretization techniques.
 # Play around with the paramters! 
 # See how many points are needed for a satisfying covering!
-no_of_points = 32
-F = BoxMap(:montecarlo, f, domain, no_of_points=no_of_points)
-p = plot!(p, F(B), color=RGBA(1.,0.,0.,0.5), lab="$no_of_points MonteCarlo test points")
+n_points = 32
+F = BoxMap(:montecarlo, f, domain, n_points = n_points)
+p = plot!(p, F(B), color=RGBA(1.,0.,0.,0.5), lab="$n_points MonteCarlo test points")
 
-no_of_points = (6, 6)
-F = BoxMap(:grid, f, domain, no_of_points=no_of_points)
-p = plot!(p, F(B), color=RGBA(0.,1.,0.,0.5), lab="$(join(no_of_points, "x")) grid of test points")
+n_points = (6, 6)
+F = BoxMap(:grid, f, domain, n_points = n_points)
+p = plot!(p, F(B), color=RGBA(0.,1.,0.,0.5), lab="$(join(n_points, "x")) grid of test points")
 
 F = BoxMap(:adaptive, f, domain)
 p = plot!(p, F(B), color=RGBA(1.,0.,1.,0.5), lab="adaptive")
 
-no_subintervals = (2, 2)
-F = BoxMap(:interval, f, domain, no_subintervals=no_subintervals)
-p = plot!(p, F(B), color=RGBA(1.,0.5,0.,0.5), lab="interval arithmetic with $(join(no_subintervals, "x")) subinterval grid")
+n_subintervals = (2, 2)
+F = BoxMap(:interval, f, domain, n_subintervals = n_subintervals)
+p = plot!(p, F(B), color=RGBA(1.,0.5,0.,0.5), lab="interval arithmetic with $(join(n_subintervals, "x")) subinterval grid")

--- a/examples/invariant_measure_1d.jl
+++ b/examples/invariant_measure_1d.jl
@@ -6,7 +6,7 @@ f(x) = μ.*x.*(1.0.-x)
 
 center, radius = 0.5, 0.5
 P = BoxPartition(Box(center, radius), (256,))
-F = BoxMap(:grid, f, P; no_of_points=(400,))
+F = BoxMap(:grid, f, P; n_points=(400,))
 
 S = cover(P, :)
 T = TransferOperator(F, S, S)

--- a/examples/recurrent_set.jl
+++ b/examples/recurrent_set.jl
@@ -84,7 +84,7 @@ f(x) = rk4_flow_map(vf, x, 0.075)
 
 center, radius = (0,0,0), (2,2,2)
 P = BoxPartition(Box(center, radius))
-F = BoxMap(:montecarlo, f, P, no_of_points = 200)
+F = BoxMap(:montecarlo, f, P, n_points = 200)
 
 S = cover(P, :)
 C = chain_recurrent_set(F, S, steps = 18)

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -58,7 +58,8 @@ export IntervalBoxMap
 export rk4, rk4_flow_map
 
 export relative_attractor, unstable_set, chain_recurrent_set
-export cover_roots, cover_manifold
+export box_dimension
+export armijo_rule, adaptive_newton_step, cover_roots, cover_manifold
 export nth_iterate_jacobian, finite_time_lyapunov_exponents
 export union_strongly_connected_components
 export seba, partition_unity, partition_disjoint, partition_likelihood

--- a/src/boxmap.jl
+++ b/src/boxmap.jl
@@ -5,10 +5,14 @@ Transforms a ``map: Q → Q`` defined on points in
 the domain ``Q ⊂ ℝᴺ`` to a `SampledBoxMap` defined 
 on `Box`es. 
 
-By default uses a grid of sample points. 
+By default uses adaptive test-point sampling. 
+For SIMD- and GPU-accelerated `BoxMap`s, uses
+a grid of test points by default. 
 """
 BoxMap(symb::Symbol, args...; kwargs...) = BoxMap(Val(symb), args...; kwargs...)
 BoxMap(symb::Symbol, accel::Symbol, args...; kwargs...) = BoxMap(symb, Val(accel), args...; kwargs...)
+BoxMap(accel::Val{:simd}, args...; kwargs...) = BoxMap(Val(:grid), accel, args...; kwargs...)
+BoxMap(accel::Val{:gpu}, args...; kwargs...) = BoxMap(Val(:grid), accel, args...; kwargs...)
 
 # default BoxMap behavior
 BoxMap(args...; kwargs...) = AdaptiveBoxMap(args...; kwargs...)

--- a/src/boxmap_cuda.jl
+++ b/src/boxmap_cuda.jl
@@ -3,7 +3,7 @@ Base.:(*)(x, ::Type{NumLiteral{T}}) where T = T(x)
 const i32, ui32 = NumLiteral{Int32}, NumLiteral{UInt32}
 
 """
-    BoxMap(:gpu, map, domain; no_of_points) -> GPUSampledBoxMap
+    BoxMap(:gpu, map, domain; n_points) -> GPUSampledBoxMap
 
 Transforms a ``map: Q → Q`` defined on points in 
 the domain ``Q ⊂ ℝᴺ`` to a `GPUSampledBoxMap` defined 
@@ -15,7 +15,6 @@ By default uses a grid of sample points.
 
 
     BoxMap(:sampled, :gpu, boxmap)
-    GPUSampledBoxMap(boxmap)
 
 Type representing a dicretization of a map using 
 sample points, which are mapped on the gpu. This 
@@ -185,7 +184,7 @@ end
 
 # constructors
 """
-    BoxMap(:pointdiscretized, :gpu, map, domain, points) -> GPUSampledBoxMap
+    BoxMap(:pointdiscretized, :gpu, map, domain::Box{N}, points) -> GPUSampledBoxMap
 
 Construct a `GPUSampledBoxMap` that uses the Vector `points` as test points. 
 `points` must be a VECTOR of test points within the unit cube 
@@ -200,39 +199,39 @@ function PointDiscretizedBoxMap(::Val{:gpu}, map, domain::Box{N,T}, points) wher
 end
 
 """
-    BoxMap(:grid, :gpu, map, domain; no_of_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
+    BoxMap(:grid, :gpu, map, domain::Box{N}; n_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
 
 Construct a `GPUSampledBoxMap` that uses a grid of test points. 
-The size of the grid is defined by `no_of_points`, which is 
+The size of the grid is defined by `n_points`, which is 
 a tuple of length equal to the dimension of the domain. 
 
 Requires a CUDA-capable gpu. 
 """
-function GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; no_of_points=ntuple(_->n_default(T),N)) where {N,T}
-    Δp = 2 ./ no_of_points
-    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(no_of_points) ]
+function GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=ntuple(_->n_default(T),N)) where {N,T}
+    Δp = 2 ./ n_points
+    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(n_points) ]
     PointDiscretizedBoxMap(c, map, domain, points)
 end
 
-function GridBoxMap(c::Val{:gpu}, map, P::BoxPartition{N,T}; no_of_points=ntuple(_->n_default(T),N)) where {N,T}
-    GridBoxMap(c, map, P.domain, no_of_points=no_of_points)
+function GridBoxMap(c::Val{:gpu}, map, P::BoxPartition{N,T}; n_points=ntuple(_->n_default(T),N)) where {N,T}
+    GridBoxMap(c, map, P.domain, n_points=n_points)
 end
 
 """
-    BoxMap(:montecarlo, :gpu, map, domain; no_of_points=16*N) -> GPUSampledBoxMap
+    BoxMap(:montecarlo, :gpu, map, domain::Box{N}; n_points=16*N) -> GPUSampledBoxMap
 
-Construct a `GPUSampledBoxMap` that uses `no_of_points` 
+Construct a `GPUSampledBoxMap` that uses `n_points` 
 Monte-Carlo test points. 
 
 Requires a CUDA-capable gpu. 
 """
-function MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; no_of_points=n_default(N,T)) where {N,T}
-    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:no_of_points ] 
+function MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=n_default(N,T)) where {N,T}
+    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:n_points ] 
     PointDiscretizedBoxMap(c, map, domain, points)
 end 
 
-function MonteCarloBoxMap(c::Val{:gpu}, map, P::BoxPartition{N,T}; no_of_points=n_default(N,T)) where {N,T}
-    MonteCarloBoxMap(c, map, P.domain; no_of_points=no_of_points)
+function MonteCarloBoxMap(c::Val{:gpu}, map, P::BoxPartition{N,T}; n_points=n_default(N,T)) where {N,T}
+    MonteCarloBoxMap(c, map, P.domain; n_points=n_points)
 end
 
 # helper + compatibility functions

--- a/src/boxmap_sampled.jl
+++ b/src/boxmap_sampled.jl
@@ -112,6 +112,9 @@ function Base.show(io::IO, g::SampledBoxMap)
     print(io, "SampledBoxMap with $(n) sample points")
 end
 
+n_default(T) = Int(pick_vector_width(T))
+n_default(N, T) = 4 * N * n_default(T)
+
 """
     BoxMap(:pointdiscretized, map, domain, points) -> SampledBoxMap
 
@@ -198,7 +201,9 @@ function approx_lipschitz(f, center::SVNT{N,T}, radius::SVNT{N,T}) where {N,T}
         L[:, dim] .= abs.(fr .- fc) ./ radius[dim]
         y[dim] = zero(T)
     end
-    all(isfinite, L) || throw(DivergedError(center, radius))
+    if !all(isfinite, L)
+        throw(NumericalError(center, radius, DIVERGED_MSG))
+    end
     return L
 end
 
@@ -212,34 +217,54 @@ Oliver Junge. “Rigorous discretization of subdivision techniques”. In:
 _International Conference on Differential Equations_. Ed. by B. Fiedler, K.
 Gröger, and J. Sprekels. 1999. 
 """
-function sample_adaptive(f, center::SVNT{N,T}, radius::SVNT{N,T}, alg=LinearAlgebra.QRIteration()) where {N,T}
+function sample_adaptive(f, center::SVNT{N,T}, radius::SVNT{N,T}; alg=LinearAlgebra.QRIteration()) where {N,T}
     L = approx_lipschitz(f, center, radius)
     _, σ, Vt = svd(L, alg=alg)
-    all(typemin(Int) .< σ .< typemax(Int)) || throw(DivergedError(center, radius))
-    n = ntuple(i->ceil(Int, σ[i]), Val(N))
-    h = 2.0 ./ (n .- 1)
+
+    if !all(typemin(Int) .< σ .< typemax(Int))
+        throw(NumericalError(center, radius, SVD_MSG))
+    end
+
+    n = ntuple(i -> ceil(Int, σ[i]), Val(N))
+    h = convert(T, 2) ./ (n .- 1)
     points = Iterators.map(CartesianIndices(n)) do i
         p  = T[ n[k] == 1 ? 0 : (i[k] - 1) * h[k] - 1 for k in 1:N ]
         p .= Vt'p
         @muladd p .= center .+ radius .* p
         sp = SVector{N,T}(p)
     end
+
     return points
 end
 
-sample_adaptive(f) = (center, radius) -> sample_adaptive(f, center, radius)
-
-function DivergedError(center::SVNT{N,T}, radius::SVNT{N,T}) where {N,T}
-    DomainError(
-        Box{N,T}(center, radius),
-        """
-        The dynamical system diverges whithin the box. 
-        Cannot calculate Lipschitz constant.  
-        Make sure that the dynamical system is well-defined 
-        or use a different `BoxMap` discretization. 
-        """
-    )
+function sample_adaptive(f)
+    domain_points(center, radius) = sample_adaptive(f, center, radius)
 end
 
-n_default(T) = Int(pick_vector_width(T))
-n_default(N, T) = 4 * N * n_default(T)
+struct NumericalError{B} <: Exception
+    box::B
+    msg::String
+end
+
+function NumericalError(center, radius::SVNT{N,T}, msg) where {N,T}
+    NumericalError(Box{N,T}(center, radius), msg)
+end
+
+function Base.showerror(io::IO, err::NumericalError)
+    println(io, "NumericalError within the box $(err.box): ")
+    println(io, err.msg)
+end
+
+const DIVERGED_MSG = """
+The dynamical system diverges. 
+Cannot calculate Lipschitz constant.  
+Make sure that the dynamical system is well-defined 
+or use a different `BoxMap` discretization. 
+"""
+
+const SVD_MSG = """
+The dynamical system is too expansive. 
+Cannot calculate a test point grid. 
+Make sure that the dynamical system is well-defined 
+or use a different `BoxMap` discretization. 
+"""

--- a/src/boxmap_simd.jl
+++ b/src/boxmap_simd.jl
@@ -1,5 +1,5 @@
 """
-    BoxMap(:cpu, map, domain; no_of_points) -> CPUSampledBoxMap
+    BoxMap(:cpu, map, domain; n_points) -> CPUSampledBoxMap
 
 Transforms a ``map: Q → Q`` defined on points in 
 the domain ``Q ⊂ ℝᴺ`` to a `CPUSampledBoxMap` defined 
@@ -11,7 +11,6 @@ By default uses a grid of sample points.
 
 
     BoxMap(:sampled, :cpu, boxmap, idx_base, temp_vec, temp_points)
-    CPUSampledBoxMap(boxmap, idx_base, temp_vec, temp_points)
 
 Type representing a discretization of a map using 
 sample points which are explicitly vectorized. This 
@@ -145,7 +144,7 @@ function CPUSampledBoxMap(boxmap::SampledBoxMap{N,T}) where {N,T}
 end
 
 """
-    BoxMap(:pointdiscretized, :cpu, map, domain, points) -> CPUSampledBoxMap
+    BoxMap(:pointdiscretized, :simd, map, domain, points) -> CPUSampledBoxMap
 
 Construct a `CPUSampledBoxMap` that uses the iterator 
 `points` as test points. `points` must have eltype 
@@ -169,46 +168,46 @@ function PointDiscretizedBoxMap(c::Val{:simd}, map, P::Q, points) where {N,T,Q<:
 end
 
 """
-    BoxMap(:grid, :cpu, map, domain; no_of_points::NTuple{N} = ntuple(_->16, N)) -> CPUSampledBoxMap
+    BoxMap(:grid, :simd, map, domain::Box{N}; n_points::NTuple{N} = ntuple(_->16, N)) -> CPUSampledBoxMap
 
 Construct a `CPUSampledBoxMap` that uses a grid of test points. 
-The size of the grid is defined by `no_of_points`, which is 
+The size of the grid is defined by `n_points`, which is 
 a tuple of length equal to the dimension of the domain. 
 The number of points is rounded up to the nearest mutiple 
 of the cpu's SIMD capacity. 
 """
-function GridBoxMap(c::Val{:simd}, map, domain::Box{N,T}; no_of_points=ntuple(_->n_default(T),N)) where {N,T}
+function GridBoxMap(c::Val{:simd}, map, domain::Box{N,T}; n_points=ntuple(_->n_default(T),N)) where {N,T}
     simd = n_default(T)
-    no_of_points = ntuple(N) do i
-        rem = no_of_points[i] % simd
-        no_of_points[i] + (rem == 0 ? rem : simd - rem)
+    n_points = ntuple(N) do i
+        rem = n_points[i] % simd
+        n_points[i] + (rem == 0 ? rem : simd - rem)
     end
-    Δp = 2 ./ no_of_points
-    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(no_of_points) ]
+    Δp = 2 ./ n_points
+    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(n_points) ]
     PointDiscretizedBoxMap(c, map, domain, points)
 end
 
-function GridBoxMap(c::Val{:simd}, map, P::Q; no_of_points=ntuple(_->n_default(T),N)) where {N,T,Q<:AbstractBoxPartition{Box{N,T}}}
-    GridBoxMap(c, map, P.domain; no_of_points=no_of_points)
+function GridBoxMap(c::Val{:simd}, map, P::Q; n_points=ntuple(_->n_default(T),N)) where {N,T,Q<:AbstractBoxPartition{Box{N,T}}}
+    GridBoxMap(c, map, P.domain; n_points=n_points)
 end
 
 """
-    BoxMap(:montecarlo, :cpu, map, domain; no_of_points=16*N) -> SampledBoxMap
+    BoxMap(:montecarlo, :simd, map, domain::Box{N}; n_points=16*N) -> SampledBoxMap
 
-Construct a `CPUSampledBoxMap` that uses `no_of_points` 
+Construct a `CPUSampledBoxMap` that uses `n_points` 
 Monte-Carlo test points. The number of points is rounded 
 up to the nearest multiple of the cpu's SIMD capacity. 
 """
-function MonteCarloBoxMap(c::Val{:simd}, map, domain::Box{N,T}; no_of_points=n_default(N,T)) where {N,T}
+function MonteCarloBoxMap(c::Val{:simd}, map, domain::Box{N,T}; n_points=n_default(N,T)) where {N,T}
     simd = n_default(T)
-    rem = no_of_points % simd
-    no_of_points = no_of_points + (rem == 0 ? rem : simd - rem)
-    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:no_of_points ] 
+    rem = n_points % simd
+    n_points = n_points + (rem == 0 ? rem : simd - rem)
+    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:n_points ] 
     PointDiscretizedBoxMap(c, map, domain, points)
 end 
 
-function MonteCarloBoxMap(c::Val{:simd}, map, P::Q; no_of_points=n_default(N,T)) where {N,T,Q<:AbstractBoxPartition{Box{N,T}}}
-    MonteCarloBoxMap(c, map, P.domain; no_of_points=no_of_points)
+function MonteCarloBoxMap(c::Val{:simd}, map, P::Q; n_points=n_default(N,T)) where {N,T,Q<:AbstractBoxPartition{Box{N,T}}}
+    MonteCarloBoxMap(c, map, P.domain; n_points=n_points)
 end
 
 # helper + compatibility functions

--- a/src/boxset.jl
+++ b/src/boxset.jl
@@ -191,6 +191,14 @@ for op in (:issubset, :isdisjoint, :issetequal, :(==))
     @eval Base.$op(b1::BoxSet, b2::BoxSet) = b1.partition == b2.partition && $op(b1.set, b2.set)
 end
 
+function max_radius(boxset::BoxSet{B,P,S}) where {N,T,I,B,P<:TreePartition{N,T,I},S}
+    min_depth = minimum(depth for (depth, cart) in boxset.set)
+    Q = BoxPartition(boxset.partition, min_depth)
+    _, r = key_to_box(Q, ntuple(_->one(I), Val(N)))
+    return r
+end
+
+max_radius(boxset::BoxSet{B,P,S}) where {B,P<:BoxPartition,S} = first(boxset).radius
 Base.isempty(boxset::BoxSet) = isempty(boxset.set)
 Base.empty!(boxset::BoxSet) = (empty!(boxset.set); boxset)
 Base.copy(boxset::BoxSet) = BoxSet(boxset.partition, copy(boxset.set))

--- a/src/no_boxmap_cuda.jl
+++ b/src/no_boxmap_cuda.jl
@@ -1,7 +1,7 @@
 # This file exists to provide docstrings for the Docs website
 
 """
-    BoxMap(:gpu, map, domain; no_of_points) -> GPUSampledBoxMap
+    BoxMap(:gpu, map, domain; n_points) -> GPUSampledBoxMap
 
 Transforms a ``map: Q → Q`` defined on points in 
 the domain ``Q ⊂ ℝᴺ`` to a `GPUSampledBoxMap` defined 
@@ -49,26 +49,26 @@ function PointDiscretizedBoxMap(c::Val{:gpu}, map, domain::Box{N,T}, points) whe
 end
 
 """
-    BoxMap(:grid, :gpu, map, domain; no_of_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
+    BoxMap(:grid, :gpu, map, domain::Box{N}; n_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
 
 Construct a `GPUSampledBoxMap` that uses a grid of test points. 
-The size of the grid is defined by `no_of_points`, which is 
+The size of the grid is defined by `n_points`, which is 
 a tuple of length equal to the dimension of the domain. 
 
-Requires a CUDA-capapble gpu.
+Requires a CUDA-capable gpu.
 """
-function GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; no_of_points=ntuple(_->4*pick_vector_width(T),N)) where {N,T}
+function GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=ntuple(_->4*pick_vector_width(T),N)) where {N,T}
     @error "Did not find a CUDA-capable gpu."
 end
     
 """
-    BoxMap(:montecarlo, :gpu, map, domain; no_of_points=16*N) -> GPUSampledBoxMap
+    BoxMap(:montecarlo, :gpu, map, domain::Box{N}; n_points=16*N) -> GPUSampledBoxMap
 
-Construct a `GPUSampledBoxMap` that uses `no_of_points` 
+Construct a `GPUSampledBoxMap` that uses `n_points` 
 Monte-Carlo test points. 
 
-Requires a CUDA-capapble gpu.
+Requires a CUDA-capable gpu.
 """
-function MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; no_of_points=4*N*pick_vector_width(T)) where {N,T}
+function MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=4*N*pick_vector_width(T)) where {N,T}
     @error "Did not find a CUDA-capable gpu."
 end

--- a/test/boxmap_interval.jl
+++ b/test/boxmap_interval.jl
@@ -8,7 +8,7 @@ using Test
     center = SVector(0.0, 0.0)
     radius = SVector(1.0, 1.0)
     domain = Box(center, radius)
-    g = BoxMap(:interval, f, domain, no_subintervals=(1,1))
+    g = BoxMap(:interval, f, domain, n_subintervals=(1,1))
     @testset "basics" begin
         @test typeof(g) <: IntervalBoxMap
         partition = BoxPartition(domain, (32,32))


### PR DESCRIPTION
While I was sitting in the hospital, bored out of my mind, I noticed that the different BoxMap constructors have different names for the same type of thing. Specifically, the keyword arguments are not uniform:
* `BoxMap(:montecarlo, f, domain, no_of_points)`
* `BoxMap(:grid, f, domain, no_of_points)`
* `BoxMap(:interval, f, domain, no_subintervals)`
Now the keywords all have the prefix `n_` as in 
* `BoxMap(:montecarlo, f, domain, n_points)`
* `BoxMap(:grid, f, domain, n_points)`
* `BoxMap(:interval, f, domain, n_subintervals)`

For very expansive systems, the default `BoxMap(:adaptive, ...)` can cause errors due to the svd algorithm not converging or the singular values being too large to represent as `Int64`. There is now a more detailed error message that helps explain this error so it doesn't just look like a bug. 

Finally, I added a more general function for computing the box dimension of any sequence of `Boxset`s. 
