### PR TITLE
Version 0.7 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GAIO"
 uuid = "33d280d1-ac47-4b0f-9c2e-fa6a385d0226"
 authors = ["The GAIO.jl Team"]
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
@@ -15,11 +15,11 @@ MatrixNetworks = "4f449596-a032-5618-b826-5a251cb6dc11"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SplitOrderedCollections = "4b700b29-7da4-4670-af42-5a9783ffd6e0"
 SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [weakdeps]
@@ -29,8 +29,6 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
-SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 
 [extensions]
 CUDAExt = "CUDA"
@@ -39,8 +37,6 @@ MakieExt = "Makie"
 MetaGraphsNextExt = "MetaGraphsNext"
 MetalExt = "Metal"
 PlotsExt = "Plots"
-ProgressMeterExt = "ProgressMeter"
-SIMDExt = "SIMD"
 
 [compat]
 Arpack = "0.5"
@@ -60,11 +56,10 @@ MuladdMacro = "0.2"
 OrderedCollections = "1.4"
 Plots = "1"
 PrecompileTools = "1"
-SIMD = "3"
+ProgressMeter = "1"
 SparseArrays = "1"
 SplitOrderedCollections = "0.1"
 SplittablesBase = "0.1"
 StaticArrays = "1"
-ThreadsX = "0.1"
 TupleTools = "1"
 julia = "1.10"

--- a/docs/src/boxmaps/adaptive.md
+++ b/docs/src/boxmaps/adaptive.md
@@ -1,6 +1,6 @@
 # `AdaptiveBoxMap`
 
-The above approaches may not necessarily be effective for covering the setwise image of a box. For choosing test points more effectively, we can use some knowledge of the Lipschitz matrix for ``f`` in a box `Box(c, r)`, that is, a matrix ``L \in \mathbb{R}^{d \times d}`` such that 
+The previous approaches may not necessarily be effective for covering the setwise image of a box. For choosing test points more effectively, we can use some knowledge of the Lipschitz matrix for ``f`` in a box `Box(c, r)`, that is, a matrix ``L \in \mathbb{R}^{d \times d}`` such that 
 ```math
 | f(y) - f(z) | \leq L \, | y - z | \quad \text{for all } y, z \in \text{Box}(c, r),
 ```
@@ -28,7 +28,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/boxmaps_cuda.md
+++ b/docs/src/boxmaps/boxmaps_cuda.md
@@ -4,11 +4,6 @@ If an Nvidia or Apple M-series gpu is available, the parallelization technique c
 
 ![performance metrics](../assets/flops_gpu_loglog.png)
 
-```@docs; canonical=false
-GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points) where {N,T}
-MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points) where {N,T}
-```
-
 ### Example
 
 ```@setup 1
@@ -27,7 +22,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/boxmaps_general.md
+++ b/docs/src/boxmaps/boxmaps_general.md
@@ -10,6 +10,8 @@ We now introduce a set of `BoxMap` subtypes for different discretization algorit
 
 ![Type Hierarchy](../assets/type_tree.jpg)
 
+!!! warning "`CPUSampledBoxMap` is deprecated"
+
 We will work from the "bottom up", starting with specific types that are of practical use, and then generalizing these approaches for the reader who wishes to know more. 
 
 ### Example
@@ -39,8 +41,8 @@ B = cover(P, (0,0))
 p = plot!(
     p, B, 
     linewidth=4, 
-    fillcolor=RGBA(0.,0.,1.,0.2), 
-    linecolor=RGBA(0.,0.,1.,0.4), 
+    fillcolor=RGBA(0.,0.4,1.,0.2), 
+    linecolor=RGBA(0.,0.4,1.,0.4), 
     lab="Box"
 )
 

--- a/docs/src/boxmaps/grid.md
+++ b/docs/src/boxmaps/grid.md
@@ -1,6 +1,6 @@
 # `GridBoxMap`
 
-Another naive but still useful approach is to place the test points on an equidistant grid within a box. This approach removes an element of randomness from the Monte-Carlo approach. 
+Another naive but still useful approach is to place the test points on an equidistant grid within a box. This approach removes randomness from the Monte-Carlo approach. 
 
 ```@docs; canonical=false
 GridBoxMap
@@ -24,7 +24,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/interval.md
+++ b/docs/src/boxmaps/interval.md
@@ -24,7 +24,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/montecarlo.md
+++ b/docs/src/boxmaps/montecarlo.md
@@ -24,7 +24,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/new_types.md
+++ b/docs/src/boxmaps/new_types.md
@@ -10,5 +10,3 @@ Subtypes of the abstract type `BoxMap` must have four restrictions:
    ```
 2. There must be a method `map_boxes(g::MyBoxMap, source::BoxSet)` which computes the setwise image of `source` under `g` and returns a `BoxSet`. 
 3. There must be a method `construct_transfers(g::BoxMap, domain::BoxSet, codomain::BoxSet)` which computes a dictionary-of-keys sparse matrix `mat` with `mat[(hit_key, source_key)] = weight` for the TransferOperator, where `hit_key ∈ codomain.set` and `source_key ∈ domain.set`. 
-4. There must be a method `construct_transfers(g::MyBoxMap, source::BoxSet)` which computes a dictionary-of-keys sparse matrix `mat` with `mat[(hit_key, source_key)] = weight` for the TransferOperator, as well as a `BoxSet` called `image` which is the setwise image of `source` (i.e. the return value of `map_boxes`). These are both returned by `construct_transfers(g::MyBoxMap, source::BoxSet)`. 
-

--- a/docs/src/boxmaps/pointdiscretized.md
+++ b/docs/src/boxmaps/pointdiscretized.md
@@ -26,7 +26,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/docs/src/boxmaps/sampled.md
+++ b/docs/src/boxmaps/sampled.md
@@ -1,7 +1,7 @@
 # `SampledBoxMap`
 
 We can even further generalize the concept of `MonteCarloBoxMap`, `GridBoxMap`, `PointDiscretizedBoxMap` as follows: we define two functions `domain_points(c, r)` and `image_points(c, r)` for any `Box(c, r)`. 
-1. for each box `Box(c, r)` a set of test points within the box is initialized using `domain_points(C, r)` and mapped forward by the point map. 
+1. for each box `Box(c, r)` a set of test points within the box is initialized using `domain_points(c, r)` and mapped forward by the point map. 
 2. For each of the pointwise images `fc`, an optional set of "perturbations" can be applied. These perturbations are generated with `image_points(fc, r)`. The boxes which are hit by these perturbations are recorded. 
 
 ```@docs; canonical=false
@@ -26,7 +26,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)
@@ -48,7 +48,7 @@ using StaticArrays
 # we will recreate the AdaptiveBoxMap using SampledBoxMap
 domain_points(center, radius) = sample_adaptive(f, center, radius)
 
-# vertices of a box
+# vertices of the box [-1, 1]ᵈ
 vertex_test_points = SVector{2,Float64}[
     (1,  1),
     (1, -1),
@@ -87,7 +87,7 @@ p = plot(cover(P, :), linewidth=0.5, fillcolor=nothing, lab="", leg=:outerbottom
 
 # unit box
 B = cover(P, (0,0))
-p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.,1.,0.2), linecolor=RGBA(0.,0.,1.,0.4), lab="Box")
+p = plot!(p, B, linewidth=4, fillcolor=RGBA(0.,0.4,1.,0.2), linecolor=RGBA(0.,0.4,1.,0.4), lab="Box")
 
 # Plot the true image of B under f.
 z = zeros(100)

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -8,65 +8,13 @@ import Base: @propagate_inbounds
 import CUDA: Adapt
 import GAIO: BoxMap, PointDiscretizedBoxMap, GridBoxMap, MonteCarloBoxMap
 import GAIO: typesafe_map, map_boxes, construct_transfers, point_to_key, ⊔, SVNT
-
-#export GPUSampledBoxMap
-
-BoxMap(::Val{Symbol("GPUSampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
-BoxMap(::Val{Symbol("gpusampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
-BoxMap(accel::Val{:gpu}, args...; kwargs...) = BoxMap(Val(:grid), accel, args...; kwargs...)
-    
-struct NumLiteral{T} end
-Base.:(*)(x, ::Type{NumLiteral{T}}) where T = T(x)
-const i32, ui32 = NumLiteral{Int32}, NumLiteral{UInt32}
-
-"""
-    BoxMap(:gpu, map, domain; n_points) -> GPUSampledBoxMap
-
-Transforms a ``map: Q → Q`` defined on points in 
-the domain ``Q ⊂ ℝᴺ`` to a `GPUSampledBoxMap` defined 
-on `Box`es. 
-
-Uses the GPU's acceleration capabilities. 
-
-By default uses a grid of sample points. 
+import GAIO: @common_gpu_code
 
 
-    BoxMap(:sampled, :gpu, boxmap)
-
-Type representing a dicretization of a map using 
-sample points, which are mapped on the gpu. This 
-type performs orders of magnitude faster than 
-standard `SampledBoxMap`s. 
-
-!!! warning "`image_points` with `GPUSampledBoxMap`"
-    `GPUSampledBoxMap` makes NO use of the `image_points` 
-    field in `SampledBoxMap`s. 
-
-Fields:
-* `boxmap`:     `SampledBoxMap` with one restriction: 
-                `boxmap.image_points` will not be used. 
+@common_gpu_code "CUDA" cu CuArray CUDA.CuArrayKernelAdaptor CUDA.KernelAdaptor
 
 
-Requires a CUDA-capable gpu. 
-"""
-struct GPUSampledBoxMap{N,T,F<:SampledBoxMap{N,T}} <: BoxMap
-    boxmap::F
-
-    function GPUSampledBoxMap(g::F) where {N,T,F<:SampledBoxMap{N,T}}
-        CUDA.functional(true)   # test if CUDA is working, or throw an error
-        if !( g.domain_points(g.domain...) isa Base.Generator{<:Union{<:CuArray,<:CuDeviceArray}} )
-            throw(AssertionError("""
-            GPU BoxMaps require one set of "global" test points in the 
-            unit box `[-1,1]^N`. In particular, `g.domain_points(c, r)` 
-            must return `rescale(c, r, points)` for a `CuArray` `points` 
-            of test points. 
-            """))
-        end
-        new{N,T,F}(g)
-    end
-end
-
-function map_boxes_kernel!(g, P, domain_points, in_keys, out_keys)
+@muladd function map_boxes_kernel!(g, P, domain_points, in_keys, out_keys)
     nk = length(in_keys)*i32
     np = length(domain_points)*i32
     ind = (blockIdx().x - 1) * blockDim().x + threadIdx().x #- 1i32
@@ -74,42 +22,45 @@ function map_boxes_kernel!(g, P, domain_points, in_keys, out_keys)
     len = nk * np #- 1i32
     for i in ind : stride : len
         m, n = CartesianIndices((np, nk))[i].I
-        p    = domain_points[m]
         key  = in_keys[n]
         box  = key_to_box(P, key)
         c, r = box
-        fp   = g(@muladd p .* r .+ c)
+        p    = domain_points[m]
+        p    = @. c + r * p
+        fp   = typesafe_map(P, g, p)
         hit  = @inbounds point_to_key(P, fp, Val(:gpu))
         out_keys[i] = isnothing(hit) ? out_of_bounds(P) : hit
     end
 end
 
 function map_boxes(
-        G::GPUSampledBoxMap{N,T}, source::BoxSet{B,Q,S}
+        g::GPUSampledBoxMap{N,T}, source::BoxSet{B,Q,S}; 
+        show_progress=false     # does nothing here
     ) where {N,T,B,Q<:BoxGrid,S}
 
-    g = G.boxmap
-    p = g.domain_points(g.domain...).iter
+    p = g.domain_points
     np = length(p)
     keys = Stateful(source.set)
+    keys_left = length(source)
     P = source.partition
     K = cu_reduce(keytype(Q))
     image = S()
-    while !isnothing(keys.nextvalstate)
-        stride = min(
-            length(keys),
+    while keys_left > 0
+        stride = min(   # estimate how many keys we can map without 
+            keys_left,  # overloading device memory
             available_array_memory() ÷ (sizeof(K) * 10 * (N + 1) * np)
         )
-        in_cpu = collect(K, take(keys, stride))
-        in_keys = CuArray{K,1}(in_cpu)
-        nk = length(in_cpu)
+        keys_left -= stride
+        keys_cpu = collect(K, take(keys, stride))
+        in_keys = CuArray{K,1}(keys_cpu)
+        nk = length(keys_cpu)
         out_keys = CuArray{K,1}(undef, nk * np)
         launch_kernel_then_sync!(
             nk * np, map_boxes_kernel!, 
             g.map, P, p, in_keys, out_keys
         )
-        out_cpu = Array{K,1}(out_keys)
-        union!(image, out_cpu)
+        keys_cpu = Array{K,1}(out_keys)
+        union!(image, keys_cpu)
         CUDA.unsafe_free!(in_keys); CUDA.unsafe_free!(out_keys)
     end
     delete!(image, out_of_bounds(P))
@@ -117,55 +68,14 @@ function map_boxes(
 end
 
 function construct_transfers(
-        G::GPUSampledBoxMap, domain::BoxSet{R,Q,S}
-    ) where {N,T,R<:Box{N,T},Q,S}
-
-    g = G.boxmap
-    p = g.domain_points(g.domain...).iter
-    np = length(p)
-    keys = Stateful(domain.set)
-    P = domain.partition
-    K = cu_reduce(keytype(Q))
-    D = Dict{Tuple{K,K},cu_reduce(T)}
-    mat = D()
-    codomain = BoxSet(P, S())
-    oob = out_of_bounds(P)
-    while !isnothing(keys.nextvalstate)
-        stride = min(
-            length(keys),
-            available_array_memory() ÷ (sizeof(K) * 10 * (N + 1) * np)
-        )
-        in_cpu = collect(K, take(keys, stride))
-        in_keys = CuArray{K,1}(in_cpu)
-        nk = length(in_cpu)
-        out_keys = CuArray{K,1}(undef, nk * np)
-        launch_kernel_then_sync!(
-            nk * np, map_boxes_kernel!, 
-            g.map, P, p, in_keys, out_keys
-        )
-        out_cpu = Array{K,1}(out_keys)
-        C = CartesianIndices((np, nk))
-        for i in 1:nk*np
-            _, n = C[i].I
-            key, hit = in_cpu[n], out_cpu[i]
-            hit == oob && continue
-            mat = mat ⊔ ((hit,key) => 1)
-        end
-        union!(codomain.set, out_cpu)
-        CUDA.unsafe_free!(in_keys); CUDA.unsafe_free!(out_keys)
-    end
-    delete!(codomain.set, oob)
-    return mat, codomain
-end
-
-function construct_transfers(
-        G::GPUSampledBoxMap, domain::BoxSet{R,Q,S}, codomain::BoxSet{U,H,W}
+        g::GPUSampledBoxMap, domain::BoxSet{R,Q,S}, codomain::BoxSet{U,H,W}; 
+        show_progress=false     # does nothing here
     ) where {N,T,R<:Box{N,T},Q,S,U,H,W}
 
-    g = G.boxmap
-    p = g.domain_points(g.domain...).iter
+    p = g.domain_points
     np = length(p)
     keys = Stateful(domain.set)
+    keys_left = length(domain)
     P = domain.partition
     P2 = codomain.partition
     P == P2 || throw(DomainError((P, P2), "Partitions of domain and codomain do not match. For GPU acceleration, they must be equal."))
@@ -174,11 +84,12 @@ function construct_transfers(
     mat = D()
     codomain = BoxSet(P2, S())
     oob = out_of_bounds(P)
-    while !isnothing(keys.nextvalstate)
+    while keys_left > 0
         stride = min(
-            length(keys),
+            keys_left,
             available_array_memory() ÷ (sizeof(K) * 10 * (N + 1) * np)
         )
+        keys_left -= stride
         in_cpu = collect(K, take(keys, stride))
         in_keys = CuArray{K,1}(in_cpu)
         nk = length(in_cpu)
@@ -201,64 +112,7 @@ function construct_transfers(
     return mat
 end
 
-# constructors
-"""
-    BoxMap(:pointdiscretized, :gpu, map, domain::Box{N}, points) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses the Vector `points` as test points. 
-`points` must be a VECTOR of test points within the unit cube 
-`[-1,1]^N`. 
-
-Requires a CUDA-capable gpu. 
-"""
-function PointDiscretizedBoxMap(::Val{:gpu}, map, domain::Box{N,T}, points) where {N,T}
-    points_vec = cu(points)
-    boxmap = PointDiscretizedBoxMap(map, domain, points_vec)
-    GPUSampledBoxMap(boxmap)
-end
-
-"""
-    BoxMap(:grid, :gpu, map, domain::Box{N}; n_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses a grid of test points. 
-The size of the grid is defined by `n_points`, which is 
-a tuple of length equal to the dimension of the domain. 
-
-Requires a CUDA-capable gpu. 
-"""
-function GridBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=ntuple(_->4,N)) where {N,T}
-    Δp = 2 ./ n_points
-    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(n_points) ]
-    PointDiscretizedBoxMap(c, map, domain, points)
-end
-
-function GridBoxMap(c::Val{:gpu}, map, P::BoxGrid{N,T}; n_points=ntuple(_->4,N)) where {N,T}
-    GridBoxMap(c, map, P.domain, n_points=n_points)
-end
-
-"""
-    BoxMap(:montecarlo, :gpu, map, domain::Box{N}; n_points=16*N) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses `n_points` 
-Monte-Carlo test points. 
-
-Requires a CUDA-capable gpu. 
-"""
-function MonteCarloBoxMap(c::Val{:gpu}, map, domain::Box{N,T}; n_points=16*N) where {N,T}
-    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:n_points ] 
-    PointDiscretizedBoxMap(c, map, domain, points)
-end 
-
-function MonteCarloBoxMap(c::Val{:gpu}, map, P::BoxGrid{N,T}; n_points=16*N) where {N,T}
-    MonteCarloBoxMap(c, map, P.domain; n_points=n_points)
-end
-
 # helper + compatibility functions
-function Base.show(io::IO, g::GPUSampledBoxMap)
-    n = length(g.boxmap.domain_points(g.boxmap.domain...).iter)
-    print(io, "GPUSampledBoxMap with $(n) sample points")
-end
-
 function launch_kernel!(n, kernel, args...)
     compiled_kernel! = @cuda launch=false kernel(args...)
     config  = launch_configuration(compiled_kernel!.fun)
@@ -279,70 +133,5 @@ function available_array_memory()
     return m.free_bytes + m.pool_reserved_bytes
 end
 
-cu_reduce(::Type{I}) where {I<:Integer} = Int32
-cu_reduce(::Type{Int16}) = Int16
-cu_reduce(::Type{Int8}) = Int8
-cu_reduce(::Type{F}) where {F<:AbstractFloat} = Float32
-cu_reduce(::Type{Float16}) = Float16
-cu_reduce(::Type{<:NTuple{N,T}}) where {N,T} = NTuple{N,cu_reduce(T)}
-
-function out_of_bounds(::P) where {N,T,I,P<:BoxGrid{N,T,I}}
-    K = cu_reduce(keytype(P))
-    K(ntuple(_->0, Val(N)))
-end
-
-function out_of_bounds(::P) where {N,T,I,P<:BoxTree{N,T,I}}
-    K = cu_reduce(keytype(P))
-    K((0, ntuple(_->0, Val(N))))
-end
-
-
-function Adapt.adapt_structure(a::A, b::BoxGrid{N,T,I}) where {N,T,I,A<:Union{<:CUDA.CuArrayKernelAdaptor,<:CUDA.KernelAdaptor}}
-    TT, II = cu_reduce(T), cu_reduce(I)
-    Adapt.adapt_storage(a, 
-        BoxGrid{N,TT,II}(
-            Box{N,TT}(b.domain...),
-            SVector{N,TT}(b.left),
-            SVector{N,TT}(b.scale),
-            SVector{N,II}(b.dims)
-        )
-    )
-end
-
-function Adapt.adapt_structure(a::A, b::BoxTree{N,T,I}) where {N,T,I,A<:Union{<:CUDA.CuArrayKernelAdaptor,<:CUDA.KernelAdaptor}}
-    TT = cu_reduce(T)
-    Adapt.adapt_storage(a,
-        BoxTree(
-            Box{N,TT}(b.domain...),
-            Adapt.adapt(a, b.nodes)
-        )
-    )
-end
-
-function Adapt.adapt_structure(
-        ::CUDA.CuArrayKernelAdaptor, x::V
-    ) where {N,M,F<:AbstractFloat,V<:AbstractArray{<:SVNT{N,F},M}}
-
-    CuArray{SVector{N,cu_reduce(F)},M}(x)
-end
-
-# hotfix to avoid errors due to cuda device-side printing
-@propagate_inbounds function point_to_key(partition::BoxGrid{N,T,I}, point, ::Val{:gpu}) where {N,T,I}
-    point in partition.domain || return nothing
-    xi = (point .- partition.left) .* partition.scale
-    x_ints = ntuple( i -> unsafe_trunc(I, xi[i]) + one(I), Val(N) )
-    @boundscheck if !checkbounds(Bool, partition, x_ints)
-        @cuprint(
-            "something went wrong in point_to_key. Fixing\n", 
-            #="point:\n    $(point.data) \n", 
-            "xi:\n    $(xi.data) \n", 
-            "x:ints:\n    $(x_ints.data) \n", 
-            "domain:\n    $(partition.domain.center.data)\n    $(partition.domain.radius.data) \n",
-            "dims:\n    $(partition.dims.data) \n"=#
-        )
-        x_ints = min.(max.(x_ints, ntuple(_->one(I),Val(N))), size(partition))
-    end
-    return x_ints
-end
 
 end # module

--- a/ext/MetalExt.jl
+++ b/ext/MetalExt.jl
@@ -1,7 +1,7 @@
 module MetalExt
     
 using GAIO, Metal, StaticArrays, MuladdMacro
-using ThreadsX
+#using ThreadsX
 
 #import Base.Iterators: Stateful, take
 import Base: unsafe_trunc
@@ -9,30 +9,11 @@ import Base: @propagate_inbounds, @boundscheck
 import Metal: Adapt
 import GAIO: BoxMap, PointDiscretizedBoxMap, GridBoxMap, MonteCarloBoxMap
 import GAIO: typesafe_map, map_boxes, construct_transfers, point_to_key, ⊔, SVNT
+import GAIO: @common_gpu_code
 
-#export GPUSampledBoxMap
 
-BoxMap(::Val{Symbol("GPUSampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
-BoxMap(::Val{Symbol("gpusampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
-BoxMap(accel::Val{:gpu}, args...; kwargs...) = BoxMap(Val(:grid), accel, args...; kwargs...)
-    
-struct NumLiteral{T} end
-Base.:(*)(x, ::Type{NumLiteral{T}}) where T = T(x)
-const i32, ui32 = NumLiteral{Int32}, NumLiteral{UInt32}
+@common_gpu_code "Metal" mtl MtlArray Metal.MtlArrayAdaptor Metal.Adaptor
 
-struct GPUSampledBoxMap{N,T,F<:Function} <: BoxMap
-    map::F
-    domain::Box{N,T}
-    domain_points::MtlArray{SVector{N,T}}
-
-    function GPUSampledBoxMap{N,T,F}(map::F, domain::Box, domain_points::MtlArray{SVector{N,T}}) where {N,T,F<:Function}
-        new{N,T,F}(map, Box{N,T}(domain...), domain_points)
-    end
-end
-
-function GPUSampledBoxMap(map::F, domain::Box, domain_points::MtlArray{SVector{N,T}}) where {N,T,F<:Function}
-    GPUSampledBoxMap{N,T,F}(map, domain, domain_points)
-end
 
 @muladd function map_boxes_kernel!(g, P::Q, in_keys, out_keys, domain_points, offset) where {N,T,B<:Box{N,T},Q<:BoxLayout{B}}
     x, y = thread_position_in_grid_2d()
@@ -47,46 +28,22 @@ end
     return nothing
 end
 
-function map_boxes(G::GPUSampledBoxMap{F}, source::BoxSet{B,Q,S}) where {B,Q,S,F}
+function map_boxes(
+        G::GPUSampledBoxMap{F}, source::BoxSet{B,Q,S}; 
+        show_progress=false     # does nothing here
+    ) where {B,Q,S,F}
+
     P = mtl(source.partition)
     _, cpu_keys = execute_boxmap(G, source)
     image = BoxSet(P, S())
-    union!(image.set, ThreadsX.Set(cpu_keys))
+    union!(image.set, cpu_keys)    # union!(image.set, ThreadsX.Set(cpu_keys))
     delete!(image.set, out_of_bounds(P))
     return image
 end
 
 function construct_transfers(
-        G::GPUSampledBoxMap{F}, domain::BoxSet{R,_Q,S}#, codomain::BoxSet{U,_H,W}
-    ) where {N,T,R<:Box{N,T},_Q,S,F}
-
-    P = domain.partition
-    codomain = BoxSet(P, S())
-    P = mtl(P)
-
-    in_cpu, out_cpu = execute_boxmap(G, domain)
-
-    oob = out_of_bounds(P)
-    Q = typeof(P)
-    K = keytype(Q)
-
-    union!(codomain.set, out_cpu)
-    delete!(codomain.set, oob)
-
-    mat = Dict{Tuple{K,K},cu_reduce(T)}()
-    for cartesian_ind in CartesianIndices(out_cpu)
-        i, j = cartesian_ind.I
-        key = in_cpu[i]
-        hit = out_cpu[i,j]
-        checkbounds(Bool, P, hit) || continue # check for oob
-        mat = mat ⊔ ((hit,key) => 1)
-    end
-
-    return mat, codomain
-end
-
-function construct_transfers(
-        G::GPUSampledBoxMap{F}, domain::BoxSet{R,_Q,S}, codomain::BoxSet{U,_H,W}
+        G::GPUSampledBoxMap{F}, domain::BoxSet{R,_Q,S}, codomain::BoxSet{U,_H,W}; 
+        show_progress=false     # does nothing here
     ) where {N,T,R<:Box{N,T},_Q,S,U,_H,W,F}
 
     P = mtl(domain.partition)
@@ -128,7 +85,7 @@ function execute_boxmap(G::GPUSampledBoxMap, source::BoxSet)
 
     leftover = n_keys % (n_groups * n_keys_per_group)
 
-    #@info "kernel initialization" n_keys n_samples n_keys_per_group n_groups leftover
+    @debug "kernel initialization" n_keys n_samples n_keys_per_group n_groups leftover
 
     @metal threads=(n_keys_per_group,n_samples) groups=n_groups map_boxes_kernel!(g, P, in_keys, out_keys, domain_points, 0i32)
 
@@ -141,139 +98,5 @@ function execute_boxmap(G::GPUSampledBoxMap, source::BoxSet)
     return Array(in_keys), Array(out_keys)
 end
 
-# constructors
-"""
-    BoxMap(:pointdiscretized, :gpu, map, domain::Box{N}, points) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses the Vector `points` as test points. 
-`points` must be a VECTOR of test points within the unit cube 
-`[-1,1]^N`. 
-
-Requires a Metal-capable gpu. 
-"""
-function PointDiscretizedBoxMap(::Val{:gpu}, map, domain::Box{N,T}, points) where {N,T}
-    domain_points = MtlArray{SVector{N,T}}(points)
-    GPUSampledBoxMap(map, domain, domain_points)
-end
-
-"""
-    BoxMap(:grid, :gpu, map, domain::Box{N}; n_points::NTuple{N} = ntuple(_->16, N)) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses a grid of test points. 
-The size of the grid is defined by `n_points`, which is 
-a tuple of length equal to the dimension of the domain. 
-
-Requires a Metal-capable gpu. 
-"""
-function GridBoxMap(::Val{:gpu}, map, domain::Box{N,T}; n_points=ntuple(_->4,N)) where {N,T}
-    Δp = 2 ./ n_points
-    points = SVector{N,T}[ Δp.*(i.I.-1).-1 for i in CartesianIndices(n_points) ]
-    GPUSampledBoxMap(map, domain, mtl(points))
-end
-
-function GridBoxMap(c::Val{:gpu}, map, P::BoxGrid{N,T}; n_points=ntuple(_->4,N)) where {N,T}
-    GridBoxMap(c, map, P.domain, n_points=n_points)
-end
-
-"""
-    BoxMap(:montecarlo, :gpu, map, domain::Box{N}; n_points=16*N) -> GPUSampledBoxMap
-
-Construct a `GPUSampledBoxMap` that uses `n_points` 
-Monte-Carlo test points. 
-
-Requires a Metal-capable gpu. 
-"""
-function MonteCarloBoxMap(::Val{:gpu}, map, domain::Box{N,T}; n_points=16*N) where {N,T}
-    points = SVector{N,T}[ 2*rand(T,N).-1 for _ = 1:n_points ] 
-    GPUSampledBoxMap(map, domain, mtl(points))
-end 
-
-function MonteCarloBoxMap(c::Val{:gpu}, map, P::BoxGrid{N,T}; n_points=16*N) where {N,T}
-    MonteCarloBoxMap(c, map, P.domain; n_points=n_points)
-end
-
-# helper + compatibility functions are almost entirely copied from CUDAExt.
-# This amount of code-copying is unfortunate, though I don't know of a good 
-# way to get around it
-
-function typesafe_map(::Q, g, p) where {N,T,B<:Box{N,T},Q<:BoxLayout{B}}
-    SVector{N,T}( g(p) )
-end
-
-# hotfix to avoid errors due to cuda device-side printing
-@propagate_inbounds function point_to_key(partition::BoxGrid{N,T,I}, point, ::Val{:gpu}) where {N,T,I}
-    point in partition.domain || return nothing
-    xi = (point .- partition.left) .* partition.scale
-    x_ints = ntuple( i -> unsafe_trunc(I, xi[i]) + one(I), Val(N) )
-    @boundscheck if !checkbounds(Bool, partition, x_ints)
-        x_ints = min.(max.(x_ints, ntuple(_->one(I),Val(N))), size(partition))
-    end
-    return x_ints
-end
-
-function out_of_bounds(::P) where {N,T,I,P<:BoxGrid{N,T,I}}
-    K = cu_reduce(keytype(P))
-    K(ntuple(_->0, Val(N)))
-end
-
-function out_of_bounds(::P) where {N,T,I,P<:BoxTree{N,T,I}}
-    K = cu_reduce(keytype(P))
-    K((0, ntuple(_->0, Val(N))))
-end
-
-function Adapt.adapt_storage(::A, (c,r)::Box{N,T}) where {N,T,A<:Union{<:Metal.MtlArrayAdaptor,<:Metal.Adaptor}}
-    TT = cu_reduce(T)
-    Box{N,TT}(c,r)
-end
-
-function Adapt.adapt_structure(a::A, b::BoxGrid{N,T,I}) where {N,T,I,A<:Union{<:Metal.MtlArrayAdaptor,<:Metal.Adaptor}}
-    TT, II = cu_reduce(T), cu_reduce(I)
-    Adapt.adapt_storage(a, 
-        BoxGrid{N,TT,II}(
-            Box{N,TT}(b.domain...),
-            SVector{N,TT}(b.left),
-            SVector{N,TT}(b.scale),
-            SVector{N,II}(b.dims)
-        )
-    )
-end
-
-function Adapt.adapt_structure(a::A, b::BoxTree{N,T,I}) where {N,T,I,A<:Union{<:Metal.MtlArrayAdaptor,<:Metal.Adaptor}}
-    TT = cu_reduce(T)
-    Adapt.adapt_storage(a,
-        BoxTree(
-            Box{N,TT}(b.domain...),
-            Adapt.adapt(a, b.nodes)
-        )
-    )
-end
-
-function Adapt.adapt_structure(
-        ::Metal.MtlArrayAdaptor, x::V
-    ) where {N,M,F<:AbstractFloat,V<:AbstractArray{<:SVNT{N,F},M}}
-
-    MtlArray{SVector{N,cu_reduce(F)},M}(x)
-end
-
-function Adapt.adapt_structure(
-        ::Metal.MtlArrayAdaptor, x::V
-    ) where {N,M,F<:Integer,V<:AbstractArray{<:NTuple{N,F},M}}
-
-    MtlArray{NTuple{N,cu_reduce(F)},M}(x)
-end
-
-function Adapt.adapt_structure(
-        ::Metal.MtlArrayAdaptor, x::V
-    ) where {N,M,H<:Integer,F<:Integer,V<:AbstractArray{<:Tuple{H,NTuple{N,F}},M}}
-
-    MtlArray{Tuple{H,NTuple{N,cu_reduce(F)}},M}(x)
-end
-
-cu_reduce(::Type{I}) where {I<:Integer} = Int32
-cu_reduce(::Type{Int16}) = Int16
-cu_reduce(::Type{Int8}) = Int8
-cu_reduce(::Type{F}) where {F<:AbstractFloat} = Float32
-cu_reduce(::Type{Float16}) = Float16
-cu_reduce(::Type{<:NTuple{N,T}}) where {N,T} = NTuple{N,cu_reduce(T)}
 
 end # module

--- a/src/GAIO.jl
+++ b/src/GAIO.jl
@@ -4,6 +4,7 @@ module GAIO
 using LinearAlgebra
 using StaticArrays
 using MuladdMacro
+using ProgressMeter
 using PrecompileTools
 using TupleTools
 const tuple_deleteat = TupleTools.deleteat
@@ -31,6 +32,7 @@ using MatrixNetworks
 using MatrixNetworks: Strong_components_output, Strong_components_rich_output
 using SparseArrays
 using Arpack
+using SparseArrays: getcolptr
 
 # misc
 import Base: unsafe_trunc, IteratorEltype, HasEltype, OneTo
@@ -115,11 +117,6 @@ include("boxmeasure.jl")
 include("transfer_operator.jl")
 #include("boxgraph.jl")
 
-@deprecate_binding BoxFun BoxMeasure
-@deprecate_binding AbstractBoxPartition BoxLayout
-@deprecate_binding BoxPartition BoxGrid
-@deprecate_binding TreePartition BoxTree
-
 include("algorithms/invariant_sets.jl")
 include("algorithms/scalar_diagnostics.jl")
 include("algorithms/optimization.jl")
@@ -130,6 +127,12 @@ include("algorithms/maps.jl")
 
 const nbhd = neighborhood
 
+include("common_gpu_code.jl")
 include("precompile.jl")
+
+@deprecate_binding BoxFun BoxMeasure
+@deprecate_binding AbstractBoxPartition BoxLayout
+@deprecate_binding BoxPartition BoxGrid
+@deprecate_binding TreePartition BoxTree
 
 end # module

--- a/src/algorithms/invariant_sets.jl
+++ b/src/algorithms/invariant_sets.jl
@@ -23,14 +23,11 @@ Compute the (chain) recurrent set over the box set `B`.
 `B` should be a (coarse) covering of the relative attractor, 
 e.g. `B = cover(P, :)` for a partition `P`.
 """
-function recurrent_set(F::BoxMap, B₀::BoxSet{Box{N,T}}; steps=12) where {N,T}
+function recurrent_set(F::BoxMap, B₀::BoxSet; steps=12)
     B = copy(B₀)
     for k in 1:steps
-        B   = subdivide(B)
-        F♯  = TransferOperator(F, B, B)
-        G   = MatrixNetwork(F♯)
-        SCC = scomponents(G)
-        B   = BoxSet(morse_tiles(F♯, SCC))
+        B = subdivide(B)
+        B = morse_tiles(F, B)
     end
     return B
 end
@@ -133,50 +130,32 @@ e.g. `B = cover(P, :)` for a partition `P`.
 function maximal_invariant_set end
 
 
-for (algorithm, func) in [
+for (algorithm, image_or_preimage) in [
         :maximal_forward_invariant_set  => preimage,
         :maximal_backward_invariant_set => restricted_image,
         :maximal_invariant_set          => symmetric_image
     ]
 
     @eval function $(algorithm)(
-            F::BoxMap, B₀::BoxSet{Box{N,T}}, subdivision::Val{true}; steps=12
-        ) where {N,T}
+            F::BoxMap, B₀::BoxSet;
+            steps=12, subdivision::Bool=true
+        )
 
-        H(B) = $(func)(F, B)
         B = copy(B₀)
         for k in 1:steps
-            B = subdivide(B)
-            B = H(B)
-        end
-        return B
-    end
-
-    @eval function $(algorithm)(
-            F::BoxMap, B₀::BoxSet{Box{N,T}}, subdivision::Val{false}; steps=12, 
-        ) where {N,T}
-
-        H(B) = $(func)(F, B)
-        B = copy(B₀)
-        for k in 1:steps
-            C = H(B)
-            B == C && break
+            subdivision  &&  ( B = subdivide(B) )
+            C = $(image_or_preimage)(F, B)
+            !subdivision  &&  C == B  &&  break
             B = C
         end
         return B
     end
 
-    @eval function $(algorithm)(
-            F::BoxMap, B₀::BoxSet{Box{N,T}};
-            steps=12, subdivision::Bool=true
-        ) where {N,T}
-
-        $(algorithm)(F, B₀, Val(subdivision); steps=steps)
-    end
-
 end
 
 #=
+# More efficient (but ugly) versions of invariant set algorithms
+
 """
 helper function to compute intersections
 """

--- a/src/algorithms/morse_graph.jl
+++ b/src/algorithms/morse_graph.jl
@@ -1,8 +1,7 @@
 function MatrixNetworks.MatrixNetwork(F♯::TransferOperator)
     @assert F♯.domain == F♯.codomain
-    adj = similar(F♯.mat, Int)
-    fill!(nonzeros(adj), 1)
-    MatrixNetwork(adj)
+    adj = copy(F♯.mat')
+    MatrixNetwork(size(adj, 1), getcolptr(adj), rowvals(adj), nonzeros(adj))
 end
 
 function MatrixNetworks.scomponents(F♯::TransferOperator)
@@ -85,6 +84,7 @@ function morse_component_map(strong_components::Strong_components_output)
     morse_component_map(strong_components, morse_map_)
 end
 
+#=
 function morse_component_map(F♯::TransferOperator)
     morse_component_map(scomponents(F♯))
 end
@@ -92,6 +92,7 @@ end
 function morse_component_map(F::BoxMap, B::BoxSet)
     morse_component_map(TransferOperator(F, B, B))
 end
+=#
 
 """
 Given a `strong_components_output` from `MatrixNetworks` (in particular 
@@ -119,6 +120,7 @@ function morse_adjacencies(strong_components::Strong_components_output, morse_ma
     return morse_adjacencies
 end
 
+#=
 function morse_adjacencies(strong_components::Strong_components_output)
     morse_map_ = morse_map(strong_components)
     morse_adjacencies(strong_components, morse_map_)
@@ -131,11 +133,14 @@ end
 function morse_adjacencies(F::BoxMap, B::BoxSet)
     morse_adjacencies(TransferOperator(F, B, B))
 end
+=#
 
 """
-Given a transfer operator and a morse component map (see 
-`morse_component_map`), compute the boxes corresponding to the vertices 
-of the morse graph. 
+Given a `BoxMap`, a domain `BoxSet` (together interpreted 
+as a transfer graph `G`), 
+compute the boxes corresponding to the vertices 
+of the morse graph. These vertices are precisely the 
+chain recurrent components of `G`
 """
 function morse_tiles(
         domain::BoxSet{R,Q,S}, morse_component_map::AbstractVector;
@@ -153,6 +158,7 @@ function morse_tiles(
     return tiles
 end
 
+#=
 function morse_tiles(
         domain::BoxSet, strong_components::Strong_components_output
     )
@@ -167,7 +173,16 @@ function morse_tiles(
 
     morse_tiles(F♯.domain, strong_components)
 end
+=#
 
+function morse_tiles(F::BoxMap, B::BoxSet)
+    F♯ = TransferOperator(F, B, B)
+    strong_components = scomponents(F♯)
+    morse_component_map_F♯ = morse_component_map(strong_components)
+    morse_tiles(F♯.domain, morse_component_map_F♯)
+end
+
+#=
 function morse_tiles(F♯::TransferOperator)
     strong_components = scomponents(F♯)
     morse_tiles(F♯, strong_components)
@@ -176,12 +191,29 @@ end
 function morse_tiles(F::BoxMap, B::BoxSet)
     morse_tiles(TransferOperator(F, B, B))
 end
+=#
 
 """
-Given a transfer operator (interpreted as a transfer graph), 
+Given a `BoxMap` and a domain `BoxSet` (together interpreted 
+as a transfer graph), 
 compute the adjacency matrix for the mose graph as well as 
 the boxes representing the vertices for the morse graph. 
 """
+function morse_adjacencies_and_tiles(F::BoxMap, B::BoxSet)
+    F♯ = TransferOperator(F, B, B)
+    adj = MatrixNetwork(F♯)
+    strong_components = scomponents(adj)
+
+    morse_map_F♯ = morse_map(strong_components)
+    morse_adjacencies_F♯ = morse_adjacencies(strong_components, morse_map_F♯)
+    
+    morse_component_map_F♯ = morse_component_map(strong_components, morse_map_F♯)
+    morse_tiles_F♯ = morse_tiles(F♯.domain, morse_component_map_F♯)
+
+    return morse_adjacencies_F♯, morse_tiles_F♯
+end
+
+#=
 function morse_adjacencies_and_tiles(F♯::TransferOperator)
     adj = MatrixNetwork(F♯)
     strong_components = scomponents(adj)
@@ -198,5 +230,13 @@ end
 function morse_adjacencies_and_tiles(F::BoxMap, B::BoxSet)
     morse_adjacencies_and_tiles(TransferOperator(F, B, B))
 end
+=#
 
-function morse_graph end
+function morse_graph(args...)
+    @warn """
+    `morse_graph` requires the package `MetaGraphsNext`. 
+    If you have not loaded this, please do so. If you have, 
+    then the MethodError is caused by a more specific problem. 
+    """
+    throw(MethodError(morse_graph, tyeof.(args)))
+end

--- a/src/algorithms/scalar_diagnostics.jl
+++ b/src/algorithms/scalar_diagnostics.jl
@@ -128,7 +128,7 @@ end
 """
     linreg(xs, ys)
 
-Simple one-dimensional lunear regression used to 
+Simple one-dimensional linear regression used to 
 approximate box dimension. 
 """
 function linreg(xs, ys)

--- a/src/boxmap.jl
+++ b/src/boxmap.jl
@@ -6,7 +6,7 @@ the domain ``Q ⊂ ℝᴺ`` to a `SampledBoxMap` defined
 on `Box`es. 
 
 By default uses adaptive test-point sampling. 
-For SIMD- and GPU-accelerated `BoxMap`s, uses
+For GPU-accelerated `BoxMap`s, uses
 a grid of test points by default. 
 """
 BoxMap(symb::Symbol, args...; kwargs...) = BoxMap(Val(symb), args...; kwargs...)
@@ -34,14 +34,6 @@ Base.show(io::IO, g::BoxMap) = print(io, "BoxMap over $(g.domain)")
 # this is a no-op outside of extensions
 preprocess(args...) = args
 
-function (g::BoxMap)(source::BoxSet; show_progress::Bool=false, kwargs...) 
-    map_boxes(g, source, Val(show_progress); kwargs...)
-end
-
-function map_boxes(g::BoxMap, source::BoxSet, show_progress::Val{false}; kwargs...)
+function (g::BoxMap)(source::BoxSet; kwargs...) 
     map_boxes(g, source; kwargs...)
-end
-
-function map_boxes(g::BoxMap, source::BoxSet, show_progress::Val{true}; kwargs...)
-    @error "Progress meter code not loaded. Run `using ProgressMeter` to get progress meters."
 end

--- a/src/boxmap_sampled.jl
+++ b/src/boxmap_sampled.jl
@@ -188,11 +188,20 @@ function typesafe_map(g::SampledBoxMap{N,T}, x::SVNT{N}) where {N,T}
     convert(SVector{N,T}, g.map(x))
 end
 
+function typesafe_map(::Q, g, p) where {N,T,B<:Box{N,T},Q<:BoxLayout{B}}
+    SVector{N,T}( g(p) )
+end
+
 # BoxMap API
 
 function map_boxes(
-        g::SampledBoxMap, source::BoxSet{B,Q,S}
+        g::SampledBoxMap, source::BoxSet{B,Q,S}; 
+        show_progress=false
     ) where {B,Q,S}
+
+    prog = Progress(length(source); 
+        desc="Computing image...", showspeed=true, enabled=show_progress
+    )
 
     P = source.partition
     @floop for box in source
@@ -209,40 +218,20 @@ function map_boxes(
                 end
             end
         end
+        next!(prog)
     end
+
     return BoxSet(P, image::S)
-end 
-
-function construct_transfers(
-        g::SampledBoxMap, domain::BoxSet{R,Q,S}
-    ) where {N,T,R<:Box{N,T},Q,S}
-
-    P = domain.partition
-    D = Dict{Tuple{keytype(Q),keytype(Q)},T}
-    @floop for key in keys(domain)
-        box = key_to_box(P, key)
-        c, r = box
-        for p in g.domain_points(c, r)
-            c = typesafe_map(g, p)
-            hitbox = point_to_box(P, c)
-            isnothing(hitbox) && continue
-            _, r = hitbox
-            for ip in g.image_points(c, r)
-                hit = point_to_key(P, ip)
-                weight = (hit,key) => 1
-                @reduce() do (image = S(); hit), (mat = D(); weight)    # Initialize empty key set and dict-of-keys sparse matrix
-                    image = image ⊔ hit                                 # Add hit key to image
-                    mat = mat ⊔ weight                                  # Add weight to mat[hit, key]
-                end
-            end
-        end
-    end
-    return mat::D, BoxSet(P, image::S)
 end
 
 function construct_transfers(
-        g::SampledBoxMap, domain::BoxSet{R,Q}, codomain::BoxSet{U,H}
+        g::SampledBoxMap, domain::BoxSet{R,Q}, codomain::BoxSet{U,H};
+        show_progress=false
     ) where {N,T,R<:Box{N,T},Q,U,H}
+
+    prog = Progress(length(domain); 
+        desc="Computing transfer weights...", showspeed=true, enabled=show_progress
+    )
 
     P1, P2 = domain.partition, codomain.partition
     D = Dict{Tuple{keytype(H),keytype(Q)},T}
@@ -263,6 +252,8 @@ function construct_transfers(
                 end
             end
         end
+        next!(prog)
     end
+    
     return mat::D
 end

--- a/src/common_gpu_code.jl
+++ b/src/common_gpu_code.jl
@@ -1,0 +1,174 @@
+"""
+Much of the code for the two gpu extensions is identical. 
+This macro generates the identical part of the code, 
+with appropriate object names. 
+"""
+macro common_gpu_code(gpuname, converter, ArrayType, ArrayAdaptor, KernelAdaptor)
+code = esc(quote
+
+
+
+BoxMap(::Val{Symbol("GPUSampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
+BoxMap(::Val{Symbol("gpusampled")}, args...; kwargs...) = GPUSampledBoxMap(args...; kwargs...)
+BoxMap(accel::Val{:gpu}, args...; kwargs...) = BoxMap(Val(:grid), accel, args...; kwargs...)
+    
+struct NumLiteral{T} end
+Base.:(*)(x, ::Type{NumLiteral{T}}) where T = T(x)
+const i32, ui32 = NumLiteral{Int32}, NumLiteral{UInt32}
+
+# Constructors are copied from CUDAExt
+"""
+    BoxMap(:gpu, map, domain; n_points) -> GPUSampledBoxMap
+
+Transforms a ``map: Q → Q`` defined on points in 
+the domain ``Q ⊂ ℝᴺ`` to a `GPUSampledBoxMap` defined 
+on `Box`es. 
+
+Uses the GPU's acceleration capabilities. 
+
+By default uses a grid of sample points. 
+
+
+    BoxMap(:montecarlo, :gpu, boxmap_args...)
+    BoxMap(:grid, :gpu, boxmap_args...)
+    BoxMap(:pointdiscretized, :gpu, boxmap_args...)
+    BoxMap(:sampled, :gpu, boxmap_args...)
+
+Type representing a dicretization of a map using 
+sample points, which are mapped on the gpu. This 
+type performs orders of magnitude faster than 
+standard `SampledBoxMap`s when point mapping is the 
+bottleneck. 
+
+!!! warning "`image_points` with `GPUSampledBoxMap`"
+    `GPUSampledBoxMap` makes NO use of the `image_points` 
+    field in `SampledBoxMap`s. 
+
+Fields:
+* `map`:              map that defines the dynamical system.
+* `domain`:           domain of the map, `B`.
+* `domain_points`:    the spread of test points to be mapped forward 
+                      in intersection algorithms.
+                      WARNING: this differs from 
+                      SampledBoxMap.domain_points in that it is a vector 
+                      of "global" test points within [-1, 1]ᴺ. 
+
+
+Requires a $($(gpuname))-capable gpu. 
+"""
+struct GPUSampledBoxMap{N,T,F<:Function} <: BoxMap
+    map::F
+    domain::Box{N,T}
+    domain_points::$ArrayType{SVector{N,T}}
+
+    function GPUSampledBoxMap{N,T,F}(map::F, domain::Box, domain_points::$ArrayType{SVector{N,T}}) where {N,T,F<:Function}
+        new{N,T,F}(map, Box{N,T}(domain...), domain_points)
+    end
+end
+
+function GPUSampledBoxMap(map::F, domain::Box, domain_points::$ArrayType{SVector{N,T}}) where {N,T,F<:Function}
+    GPUSampledBoxMap{N,T,F}(map, domain, domain_points)
+end
+
+function GPUSampledBoxMap(boxmap::SampledBoxMap{N}) where {N}
+    c, r = boxmap.domain
+    points = collect(boxmap.domain_points(c, r))
+    map!(x -> (x .- c) ./ r, points, points)    # send all points to [-1, 1]ᴺ
+    GPUSampledBoxMap(boxmap.map, boxmap.domain, $converter(points))
+end
+
+function BoxMap(symb::Symbol, ::Val{:gpu}, args...; kwargs...)
+    F = BoxMap(symb, args...; kwargs...)
+    GPUSampledBoxMap(F)
+end
+
+# helper + compatibility functions
+function Base.show(io::IO, g::GPUSampledBoxMap)
+    n = length(g.domain_points)
+    print(io, "GPUSampledBoxMap with $(n) sample points")
+end
+
+# hotfix to avoid errors due to cuda device-side printing
+@propagate_inbounds function point_to_key(partition::BoxGrid{N,T,I}, point, ::Val{:gpu}) where {N,T,I}
+    point in partition.domain || return nothing
+    xi = (point .- partition.left) .* partition.scale
+    x_ints = ntuple( i -> unsafe_trunc(I, xi[i]) + one(I), Val(N) )
+    @boundscheck if !checkbounds(Bool, partition, x_ints)
+        x_ints = min.(max.(x_ints, ntuple(_->one(I),Val(N))), size(partition))
+    end
+    return x_ints
+end
+
+function out_of_bounds(::P) where {N,T,I,P<:BoxGrid{N,T,I}}
+    K = cu_reduce(keytype(P))
+    K(ntuple(_->0, Val(N)))
+end
+
+function out_of_bounds(::P) where {N,T,I,P<:BoxTree{N,T,I}}
+    K = cu_reduce(keytype(P))
+    K((0, ntuple(_->0, Val(N))))
+end
+
+function Adapt.adapt_storage(::A, (c,r)::Box{N,T}) where {N,T,A<:Union{<:$ArrayAdaptor,<:$KernelAdaptor}}
+    TT = cu_reduce(T)
+    Box{N,TT}(c,r)
+end
+
+function Adapt.adapt_structure(a::A, b::BoxGrid{N,T,I}) where {N,T,I,A<:Union{<:$ArrayAdaptor,<:$KernelAdaptor}}
+    TT, II = cu_reduce(T), cu_reduce(I)
+    Adapt.adapt_storage(a, 
+        BoxGrid{N,TT,II}(
+            Box{N,TT}(b.domain...),
+            SVector{N,TT}(b.left),
+            SVector{N,TT}(b.scale),
+            SVector{N,II}(b.dims)
+        )
+    )
+end
+
+function Adapt.adapt_structure(a::A, b::BoxTree{N,T,I}) where {N,T,I,A<:Union{<:$ArrayAdaptor,<:$KernelAdaptor}}
+    TT = cu_reduce(T)
+    Adapt.adapt_storage(a,
+        BoxTree(
+            Box{N,TT}(b.domain...),
+            Adapt.adapt(a, b.nodes)
+        )
+    )
+end
+
+function Adapt.adapt_structure(
+        ::$ArrayAdaptor, x::V
+    ) where {N,M,F<:AbstractFloat,V<:AbstractArray{<:SVNT{N,F},M}}
+
+    $ArrayType{SVector{N,cu_reduce(F)},M}(x)
+end
+
+function Adapt.adapt_structure(
+        ::$ArrayAdaptor, x::V
+    ) where {N,M,F<:Integer,V<:AbstractArray{<:NTuple{N,F},M}}
+
+    $ArrayType{NTuple{N,cu_reduce(F)},M}(x)
+end
+
+function Adapt.adapt_structure(
+        ::$ArrayAdaptor, x::V
+    ) where {N,M,H<:Integer,F<:Integer,V<:AbstractArray{<:Tuple{H,NTuple{N,F}},M}}
+
+    $ArrayType{Tuple{H,NTuple{N,cu_reduce(F)}},M}(x)
+end
+
+cu_reduce(::Type{I}) where {I<:Integer} = Int32
+cu_reduce(::Type{Int16}) = Int16
+cu_reduce(::Type{Int8}) = Int8
+cu_reduce(::Type{F}) where {F<:AbstractFloat} = Float32
+cu_reduce(::Type{Float16}) = Float16
+cu_reduce(::Type{<:NTuple{N,T}}) where {N,T} = NTuple{N,cu_reduce(T)}
+
+
+
+end)
+
+
+#display(code)
+return code
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -25,22 +25,22 @@ PrecompileTools.@setup_workload begin
 
             _F = BoxMap(_f, _Q)
             _C = _F(_S)
-            _𝔽 = TransferOperator(_F, _S)
+            #_𝔽 = TransferOperator(_F, _S)
             _𝔽 = TransferOperator(_F, _S, _S)
 
             _F = BoxMap(:interval, _f, _Q)
             _C = _F(_S)
-            _𝔽 = TransferOperator(_F, _S)
+            #_𝔽 = TransferOperator(_F, _S)
             _𝔽 = TransferOperator(_F, _S, _S)
 
             _F = BoxMap(:montecarlo, _f, _Q, n_points=1)
             _C = _F(_S)
-            _𝔽 = TransferOperator(_F, _S)
+            #_𝔽 = TransferOperator(_F, _S)
             _𝔽 = TransferOperator(_F, _S, _S)
 
             _F = BoxMap(:grid, _f, _Q, n_points=ntuple(_->1, dim))
             _C = _F(_S)
-            _𝔽 = TransferOperator(_F, _S)
+            #_𝔽 = TransferOperator(_F, _S)
             _𝔽 = TransferOperator(_F, _S, _S)
 
             _μ = BoxMeasure(_S, T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,11 +40,6 @@ ENV["JULIA_DEBUG"] = GAIO
     @safetestset "SampledBoxMap" begin
         include("boxmap.jl")
     end
-
-    @info "testing boxmap_simd.jl"
-    @safetestset "SampledBoxMap :simd" begin
-        include("boxmap_simd.jl")
-    end
     
     if ( isapple() && ARCH === :aarch64 ) || CUDA.functional()
         @info "testing boxmap_gpu.jl"
@@ -56,11 +51,6 @@ ENV["JULIA_DEBUG"] = GAIO
     @info "testing boxmap_interval.jl"
     @safetestset "IntervalBoxMap" begin
         include("boxmap_interval.jl")
-    end
-
-    @info "testing progressmeter.jl"
-    @safetestset "Progrss Meter" begin
-        include("progressmeter.jl")
     end
 
     @info "testing boxmeasure.jl"

--- a/test/transfer_operator.jl
+++ b/test/transfer_operator.jl
@@ -18,15 +18,6 @@ using Test
     F = BoxMap(:grid, f, domain)
     P = BoxGrid(domain, (16,16))
 
-    S = cover(P, (0,0))
-    F♯ = TransferOperator(F, S)
-    @test F♯.codomain == F(S)
-
-    μ = BoxMeasure(S, (1,))
-    @test BoxSet(μ) == S
-    ν = F♯ * μ
-    @test BoxSet(ν) == F(S)
-
     S = cover(P, :)
     F♯ = TransferOperator(F, S, S)
 

--- a/test/unstable_manifold.jl
+++ b/test/unstable_manifold.jl
@@ -17,9 +17,7 @@ using Test
     for (name, args) in [
             "montecarlo"        => (:montecarlo,),
             "grid"              => (:grid,),
-            "adaptive"          => (:adaptive,),
-            "simd montecarlo"   => (:montecarlo, :simd),
-            "simd grid"         => (:grid, :simd)
+            "adaptive"          => (:adaptive,)
         ]
 
         @testset "$name" begin
@@ -30,7 +28,6 @@ using Test
             @info "benchmark run $name"
             @time W = unstable_set(F, S);
         
-            T = TransferOperator(F, W)
             T = TransferOperator(F, W, W)
             λ, ev, nconv = eigs(T, nev=1, tol=100*eps())
             @test ev[1] isa BoxMeasure  # passes if no error is thrown    
@@ -49,7 +46,6 @@ using Test
             W = unstable_set(F, S)
             @test W isa BoxSet  # passes if no error is thrown
         
-            T = TransferOperator(F, W; show_progress=true)
             T = TransferOperator(F, W, W; show_progress=true)
             λ, ev, nconv = eigs(T, nev=1, tol=100*eps())
             @test ev[1] isa BoxMeasure  # passes if no error is thrown    

--- a/test/unstable_manifold_gpu.jl
+++ b/test/unstable_manifold_gpu.jl
@@ -24,14 +24,13 @@ end
 
     @testset "gpu montecarlo" begin
         F = BoxMap(:montecarlo, :gpu, f, domain)
-        W = unstable_set(F, S)
-        @test W isa BoxSet # passes if no error is thrown
+        #W = unstable_set(F, S)
+        #@test W isa BoxSet # passes if no error is thrown
         #@info "length of unstable set gpu montecarlo" W
 
         @info "benchmark run gpu montecarlo"
         @time W = unstable_set(F, S);
 
-        T = TransferOperator(F, W)
         T = TransferOperator(F, W, W)
         λ, ev, nconv = eigs(T, nev=1, tol=100*eps())
         @test ev[1] isa BoxMeasure # passes if no error is thrown


### PR DESCRIPTION
These are the updates that we discussed a few weeks ago. Changes include: 

- Transfer operators now only accept the signature `TransferOperator(F::BoxMap, domain::BoxSet, codomain::BoxSet)`. The signature `TransferOperator(F::BoxMap, domain::BoxSet)` is no longer allowed. In particular, on-the-fly changes of the domain / codomain will no longer occur. This simplifies transfer operator code significantly and leads to less surface for bugs to appear. 
- Move progress meter code into codebase directly. This simplifies the code so maintenance is much easier
- Remove SIMD extension. It (in my opinion) creates far more work in maintenance than it is worth, it's really not that much faster
- Morse graph API now works only with maps and domains, i.e. no longer allows calling e.g. `morse_graph(transferoperator)`. This keeps the API consistent
- Certain algorithms for invariant sets are simplified. Depending on how the new GAIO.jl paper looks, we can adjust these further to match
- Refactor GPU code to remove code duplication

Still todo: 
- ~~tests~~ (new tests are in)
- Documentation (oh how I dread this...)

Hopefully once this is finished, we can move directly into a version 1.0. 